### PR TITLE
MEN-952 Fix reader panic while reading malformed tar archive.

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -278,7 +278,7 @@ func (ar *Reader) ReadNextDataFile() (parser.Parser, error) {
 	if err == io.EOF {
 		return nil, io.EOF
 	} else if err != nil {
-		return nil, errors.Wrapf(err, "reader: error reading update file: "+hdr.Name)
+		return nil, errors.Wrapf(err, "reader: error reading update file: [%v]", hdr)
 	}
 	if strings.Compare(filepath.Dir(hdr.Name), "data") != 0 {
 		return nil, errors.New("reader: invalid data file name: " + hdr.Name)


### PR DESCRIPTION
After tar reader returns error, `hdr` variable might be left unset
in `ReadNextDataFile` and dereferencing it to log the `hdr.Name`
ends up with panic.

Signed-off-by: Marcin Pasinski <marcin.pasinski@cfengine.com>