### PR TITLE
MEN-1028 don't crash when device type in not provided.

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -30,7 +30,7 @@ import (
 var Version = "unknown"
 
 func writeArtifact(c *cli.Context) error {
-	if len(c.String("device-type")) == 0 || len(c.String("artifact-name")) == 0 ||
+	if len(c.StringSlice("device-type")) == 0 || len(c.String("artifact-name")) == 0 ||
 		len(c.String("update")) == 0 {
 		return errors.New("must provide `device-type`, `artifact-name` and `update`")
 	}


### PR DESCRIPTION
While using `mender-artifact` CLI it crashed without providing
device type.

Signed-off-by: Marcin Pasinski <marcin.pasinski@cfengine.com>