### PR TITLE
Fix signer unit tests.

### DIFF
--- a/artifact/signer_test.go
+++ b/artifact/signer_test.go
@@ -209,7 +209,9 @@ func TestECDSA(t *testing.T) {
 	// use invalid signature
 	v = NewVerifier([]byte(PublicECDSAKey))
 	// change the first byte of the signature
-	sig[0]++
+	sig, err = s.Sign([]byte("this is a different message"))
+	assert.NoError(t, err)
+
 	err = v.Verify(msg, sig)
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(), "verification failed")


### PR DESCRIPTION
Changing the first byte of the signature is causing errors
while executing tests, when we are ending up with
"illegal base64 data at input byte 0".

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>