### PR TITLE
MEN-1198 Stop reading artifact when signature is missing.

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -158,6 +158,10 @@ func (ar *Reader) GetHandlers() map[int]handlers.Installer {
 }
 
 func (ar *Reader) readHeaderV1(tReader *tar.Reader) error {
+	if ar.signed {
+		return errors.New("reader: expecting signed artifact; " +
+			"v1 is not supporting signatures")
+	}
 	hdr, err := getNext(tReader)
 	if err != nil {
 		return errors.New("reader: error reading header")

--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -197,6 +197,14 @@ func TestReadSigned(t *testing.T) {
 	aReader = NewReader(art)
 	err = aReader.ReadArtifact()
 	assert.NoError(t, err)
+
+	art, err = MakeRootfsImageArtifact(1, false, false)
+	assert.NoError(t, err)
+	aReader = NewReaderSigned(art)
+	err = aReader.ReadArtifact()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"reader: expecting signed artifact")
 }
 
 func TestRegisterMultipleHandlers(t *testing.T) {


### PR DESCRIPTION
If we are expecting artifact to be signed, `NewReaderSigned`
instead of `NewReader` should be used. This will allow failing
immediately after discovering that signature is missing.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>