### PR TITLE
MEN-1183: Switch default artifact format version to 2.

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -231,13 +231,13 @@ func readArtifact(c *cli.Context) error {
 func getKey(path string) ([]byte, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, errors.New("Invialid key path.")
+		return nil, fmt.Errorf("Invalid key path: %s", path)
 	}
 	defer f.Close()
 
 	key := bytes.NewBuffer(nil)
 	if _, err := io.Copy(key, f); err != nil {
-		return nil, errors.New("Error reading key.")
+		return nil, fmt.Errorf("Error reading key: %s", path)
 	}
 	return key.Bytes(), nil
 }

--- a/artifacts.go
+++ b/artifacts.go
@@ -32,14 +32,11 @@ import (
 // Version of the mender-artifact CLI tool
 var Version = "unknown"
 
+// Latest version of the format, which is also what we default to.
+const LatestFormatVersion = 2
+
 func version(c *cli.Context) int {
 	version := c.Int("version")
-	// set version to 2 if artifact is signed or scripts are provided and version
-	// is not set explicitly
-	if !c.IsSet("version") &&
-		(len(c.String("key")) != 0 || len(c.StringSlice("script")) > 0) {
-		version = 2
-	}
 	return version
 }
 
@@ -325,7 +322,7 @@ func run() error {
 		cli.IntFlag{
 			Name:  "version, v",
 			Usage: "Version of the artifact.",
-			Value: 1,
+			Value: LatestFormatVersion,
 		},
 		cli.StringFlag{
 			Name:  "key, k",

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -169,7 +169,7 @@ func TestArtifactsSigned(t *testing.T) {
 		"-k", "non-existing-private.key"}
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "Invialid key path.", errors.Cause(err).Error())
+	assert.Contains(t, errors.Cause(err).Error(), "Invalid key path")
 
 	// store named file
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
@@ -202,7 +202,7 @@ func TestArtifactsSigned(t *testing.T) {
 		filepath.Join(updateTestDir, "artifact.mender")}
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "Invialid key path.", errors.Cause(err).Error())
+	assert.Contains(t, errors.Cause(err).Error(), "Invalid key path")
 
 	// validate
 	os.Args = []string{"mender-artifact", "validate",
@@ -217,7 +217,7 @@ func TestArtifactsSigned(t *testing.T) {
 		filepath.Join(updateTestDir, "artifact.mender")}
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "Invialid key path.", errors.Cause(err).Error())
+	assert.Contains(t, errors.Cause(err).Error(), "Invalid key path")
 
 	// invalid version
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",


### PR DESCRIPTION
Also remove the section that auto-promotes version to 2 under certain
conditions. This code will never execute anymore now that the default
is 2.