### PR TITLE
Update state scripts to new naming schema.

### DIFF
--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -89,7 +89,7 @@ func MakeRootfsImageArtifact(version int, signed bool,
 
 	scr := artifact.Scripts{}
 	if hasScripts {
-		s, err := ioutil.TempFile("", "10_ArtifactDownload.Enter.")
+		s, err := ioutil.TempFile("", "ArtifactDownload_Enter_10_")
 		if err != nil {
 			return nil, err
 		}
@@ -254,7 +254,7 @@ func TestReadWithScripts(t *testing.T) {
 	aReader.ScriptsReadCallback = func(r io.Reader, info os.FileInfo) error {
 		noExec++
 
-		assert.Contains(t, info.Name(), "10_ArtifactDownload.Enter.")
+		assert.Contains(t, info.Name(), "ArtifactDownload_Enter_10_")
 
 		buf := bytes.NewBuffer(nil)
 		_, err = io.Copy(buf, r)

--- a/artifact/scripter.go
+++ b/artifact/scripter.go
@@ -26,17 +26,15 @@ type Scripts struct {
 }
 
 var availableScriptType = map[string]bool{
-	"Idle":                true,
-	"Sync":                true,
-	"ArtifactDownload":    true,
-	"ArtifactPreinstall":  true,
-	"ArtifactInstall":     true,
-	"Reboot":              true,
-	"ArtifactPostinstall": true,
-	"ArtifactCommit":      true,
-	"Rollback":            true,
-	"RollbackReboot":      true,
-	"ArtifactFailure":     true,
+	"Idle":                   true,
+	"Sync":                   true,
+	"ArtifactDownload":       true,
+	"ArtifactInstall":        true,
+	"ArtifactReboot":         true,
+	"ArtifactCommit":         true,
+	"ArtifactRollback":       true,
+	"ArtifactRollbackReboot": true,
+	"ArtifactError":          true,
 }
 
 func (s *Scripts) Add(path string) error {
@@ -46,8 +44,8 @@ func (s *Scripts) Add(path string) error {
 
 	name := filepath.Base(path)
 
-	// all scripts must be formated like `10_ArtifactDownload.Enter.ask-user`
-	re := regexp.MustCompile(`[0-9][0-9]_([A-Za-z]+)\.(Enter|Leave)(\.\S+)?`)
+	// all scripts must be formated like `ArtifactDownload_Enter_05_wifi-driver`
+	re := regexp.MustCompile(`([A-Za-z]+)_(Enter|Leave|Error)_[0-9][0-9](_\S+)?`)
 
 	// `matches` should contain a slice of string of match of regex;
 	// the first element should be the whole matched name of the script and

--- a/artifact/scripter_test.go
+++ b/artifact/scripter_test.go
@@ -22,41 +22,41 @@ import (
 
 func TestAdding(t *testing.T) {
 	s := Scripts{}
-	err := s.Add(`10_ArtifactDownload.Enter.ask-user`)
+	err := s.Add(`ArtifactDownload_Enter_10_ask-user`)
 	assert.NoError(t, err)
 	assert.Len(t, s.names, 1)
 
 	list := s.Get()
 	assert.Len(t, list, 1)
-	assert.Equal(t, "10_ArtifactDownload.Enter.ask-user", list[0])
+	assert.Equal(t, "ArtifactDownload_Enter_10_ask-user", list[0])
 
-	err = s.Add(`10_ArtifactDownload.Leave`)
+	err = s.Add(`ArtifactDownload_Leave_10`)
 	assert.NoError(t, err)
 	assert.Len(t, s.names, 2)
 
-	err = s.Add(`/some_directory/11_ArtifactDownload.Enter`)
+	err = s.Add(`/some_directory/ArtifactDownload_Enter_11`)
 	assert.NoError(t, err)
 	assert.Len(t, s.names, 3)
 
 	// script already exists
-	err = s.Add(`11_ArtifactDownload.Enter`)
+	err = s.Add(`ArtifactDownload_Enter_11`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "script already exists")
 	assert.Len(t, s.names, 3)
 
 	// non existing state
-	err = s.Add(`10_InvalidState.Enter`)
+	err = s.Add(`InvalidState_Enter_10`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported script state")
 	assert.Len(t, s.names, 3)
 
 	// bad formatting
-	err = s.Add(`10_ArtifactDownload.Bad`)
+	err = s.Add(`ArtifactDownload_Bad_10`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid script")
 	assert.Len(t, s.names, 3)
 
-	err = s.Add(`ArtifactDownload.Enter`)
+	err = s.Add(`ArtifactDownload_Enter`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid script")
 	assert.Len(t, s.names, 3)

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -302,12 +302,12 @@ func TestWithScripts(t *testing.T) {
 				IsDir:   false,
 			},
 			{
-				Path:    "99_ArtifactDownload.Enter",
+				Path:    "ArtifactDownload_Enter_99",
 				Content: []byte("this is first enter script"),
 				IsDir:   false,
 			},
 			{
-				Path:    "01_ArtifactPreinstall.Leave",
+				Path:    "ArtifactInstall_Leave_01",
 				Content: []byte("this is leave script"),
 				IsDir:   false,
 			},
@@ -318,8 +318,8 @@ func TestWithScripts(t *testing.T) {
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
 		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),
 		"-o", filepath.Join(updateTestDir, "artifact.mender"),
-		"-s", filepath.Join(updateTestDir, "99_ArtifactDownload.Enter"),
-		"-s", filepath.Join(updateTestDir, "01_ArtifactPreinstall.Leave")}
+		"-s", filepath.Join(updateTestDir, "ArtifactDownload_Enter_99"),
+		"-s", filepath.Join(updateTestDir, "ArtifactInstall_Leave_01")}
 	err = run()
 	assert.NoError(t, err)
 
@@ -333,7 +333,7 @@ func TestWithScripts(t *testing.T) {
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
 		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),
 		"-o", filepath.Join(updateTestDir, "artifact.mender"),
-		"-s", filepath.Join(updateTestDir, "99_ArtifactDownload.Enter"),
+		"-s", filepath.Join(updateTestDir, "ArtifactDownload_Enter_99"),
 		"-v", "1"}
 	fakeErrWriter.Reset()
 	err = run()

--- a/awriter/writer_test.go
+++ b/awriter/writer_test.go
@@ -172,7 +172,7 @@ func TestWithScripts(t *testing.T) {
 	u := handlers.NewRootfsV1(upd)
 	updates := &Updates{U: []handlers.Composer{u}}
 
-	scr, err := ioutil.TempFile("", "10_ArtifactDownload.Enter.")
+	scr, err := ioutil.TempFile("", "ArtifactDownload_Enter_10_")
 	assert.NoError(t, err)
 	defer os.Remove(scr.Name())
 


### PR DESCRIPTION
Use `STATE_[Enter|Leave|Error]_NUM[_optional-script-name]` schema
for naming state scripts.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>