### PR TITLE
MEN-1229 Remove parameter allowing adding scripts.

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -344,11 +344,6 @@ func run() error {
 			Name:  "key, k",
 			Usage: "Full path to the private key that will be used to sign the artifact.",
 		},
-		cli.StringSliceFlag{
-			Name: "script, s",
-			Usage: "Full path to the state script(s). You can specify multiple " +
-				"scripts providing this parameter multiple times.",
-		},
 	}
 
 	write := cli.Command{

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -290,58 +290,6 @@ func TestArtifactsRead(t *testing.T) {
 		fakeErrWriter.String())
 }
 
-func TestWithScripts(t *testing.T) {
-	updateTestDir, _ := ioutil.TempDir("", "update")
-	defer os.RemoveAll(updateTestDir)
-
-	err := MakeFakeUpdateDir(updateTestDir,
-		[]TestDirEntry{
-			{
-				Path:    "update.ext4",
-				Content: []byte("my update"),
-				IsDir:   false,
-			},
-			{
-				Path:    "99_ArtifactDownload.Enter",
-				Content: []byte("this is first enter script"),
-				IsDir:   false,
-			},
-			{
-				Path:    "01_ArtifactPreinstall.Leave",
-				Content: []byte("this is leave script"),
-				IsDir:   false,
-			},
-		})
-	assert.NoError(t, err)
-
-	// write artifact
-	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
-		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),
-		"-o", filepath.Join(updateTestDir, "artifact.mender"),
-		"-s", filepath.Join(updateTestDir, "99_ArtifactDownload.Enter"),
-		"-s", filepath.Join(updateTestDir, "01_ArtifactPreinstall.Leave")}
-	err = run()
-	assert.NoError(t, err)
-
-	// read artifact
-	os.Args = []string{"mender-artifact", "read",
-		filepath.Join(updateTestDir, "artifact.mender")}
-	err = run()
-	assert.NoError(t, err)
-
-	// write artifact vith invalid version
-	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
-		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),
-		"-o", filepath.Join(updateTestDir, "artifact.mender"),
-		"-s", filepath.Join(updateTestDir, "99_ArtifactDownload.Enter"),
-		"-v", "1"}
-	fakeErrWriter.Reset()
-	err = run()
-	assert.Error(t, err)
-	assert.Equal(t, "can not use scripts artifact with version 1\n",
-		fakeErrWriter.String())
-}
-
 type TestDirEntry struct {
 	Path    string
 	Content []byte


### PR DESCRIPTION
For version 2.0 we are disabling the ability of adding state
scripts as the functionality is not implemented client and backend
side.

Changelog: Remove support for adding state script for version 2.0

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>