### PR TITLE
Make ArtifactDownload state part of rootfs script.

### DIFF
--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -89,7 +89,7 @@ func MakeRootfsImageArtifact(version int, signed bool,
 
 	scr := artifact.Scripts{}
 	if hasScripts {
-		s, err := ioutil.TempFile("", "ArtifactDownload_Enter_10_")
+		s, err := ioutil.TempFile("", "ArtifactInstall_Enter_10_")
 		if err != nil {
 			return nil, err
 		}
@@ -254,7 +254,7 @@ func TestReadWithScripts(t *testing.T) {
 	aReader.ScriptsReadCallback = func(r io.Reader, info os.FileInfo) error {
 		noExec++
 
-		assert.Contains(t, info.Name(), "ArtifactDownload_Enter_10_")
+		assert.Contains(t, info.Name(), "ArtifactInstall_Enter_10_")
 
 		buf := bytes.NewBuffer(nil)
 		_, err = io.Copy(buf, r)

--- a/artifact/scripter.go
+++ b/artifact/scripter.go
@@ -26,15 +26,17 @@ type Scripts struct {
 }
 
 var availableScriptType = map[string]bool{
-	"Idle":                   true,
-	"Sync":                   true,
-	"ArtifactDownload":       true,
+	// Idle, Sync and Download scripts are part of rootfs and can not
+	// be a part of the artifact itself; Leaving below for refference...
+	//"Idle":                   true,
+	//"Sync":                   true,
+	//"Download":               true,
 	"ArtifactInstall":        true,
 	"ArtifactReboot":         true,
 	"ArtifactCommit":         true,
 	"ArtifactRollback":       true,
 	"ArtifactRollbackReboot": true,
-	"ArtifactError":          true,
+	"ArtifactFailure":        true,
 }
 
 func (s *Scripts) Add(path string) error {
@@ -44,7 +46,7 @@ func (s *Scripts) Add(path string) error {
 
 	name := filepath.Base(path)
 
-	// all scripts must be formated like `ArtifactDownload_Enter_05_wifi-driver`
+	// all scripts must be formated like `ArtifactInstall_Enter_05_wifi-driver`
 	re := regexp.MustCompile(`([A-Za-z]+)_(Enter|Leave|Error)_[0-9][0-9](_\S+)?`)
 
 	// `matches` should contain a slice of string of match of regex;

--- a/artifact/scripter_test.go
+++ b/artifact/scripter_test.go
@@ -22,24 +22,24 @@ import (
 
 func TestAdding(t *testing.T) {
 	s := Scripts{}
-	err := s.Add(`ArtifactDownload_Enter_10_ask-user`)
+	err := s.Add(`ArtifactCommit_Enter_10_ask-user`)
 	assert.NoError(t, err)
 	assert.Len(t, s.names, 1)
 
 	list := s.Get()
 	assert.Len(t, list, 1)
-	assert.Equal(t, "ArtifactDownload_Enter_10_ask-user", list[0])
+	assert.Equal(t, "ArtifactCommit_Enter_10_ask-user", list[0])
 
-	err = s.Add(`ArtifactDownload_Leave_10`)
+	err = s.Add(`ArtifactCommit_Leave_10`)
 	assert.NoError(t, err)
 	assert.Len(t, s.names, 2)
 
-	err = s.Add(`/some_directory/ArtifactDownload_Enter_11`)
+	err = s.Add(`/some_directory/ArtifactCommit_Enter_11`)
 	assert.NoError(t, err)
 	assert.Len(t, s.names, 3)
 
 	// script already exists
-	err = s.Add(`ArtifactDownload_Enter_11`)
+	err = s.Add(`ArtifactCommit_Enter_11`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "script already exists")
 	assert.Len(t, s.names, 3)
@@ -51,12 +51,12 @@ func TestAdding(t *testing.T) {
 	assert.Len(t, s.names, 3)
 
 	// bad formatting
-	err = s.Add(`ArtifactDownload_Bad_10`)
+	err = s.Add(`ArtifactCommit_Bad_10`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid script")
 	assert.Len(t, s.names, 3)
 
-	err = s.Add(`ArtifactDownload_Enter`)
+	err = s.Add(`ArtifactCommit_Enter`)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid script")
 	assert.Len(t, s.names, 3)

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -302,7 +302,7 @@ func TestWithScripts(t *testing.T) {
 				IsDir:   false,
 			},
 			{
-				Path:    "ArtifactDownload_Enter_99",
+				Path:    "ArtifactInstall_Enter_99",
 				Content: []byte("this is first enter script"),
 				IsDir:   false,
 			},
@@ -318,7 +318,7 @@ func TestWithScripts(t *testing.T) {
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
 		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),
 		"-o", filepath.Join(updateTestDir, "artifact.mender"),
-		"-s", filepath.Join(updateTestDir, "ArtifactDownload_Enter_99"),
+		"-s", filepath.Join(updateTestDir, "ArtifactInstall_Enter_99"),
 		"-s", filepath.Join(updateTestDir, "ArtifactInstall_Leave_01")}
 	err = run()
 	assert.NoError(t, err)
@@ -333,7 +333,7 @@ func TestWithScripts(t *testing.T) {
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
 		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),
 		"-o", filepath.Join(updateTestDir, "artifact.mender"),
-		"-s", filepath.Join(updateTestDir, "ArtifactDownload_Enter_99"),
+		"-s", filepath.Join(updateTestDir, "ArtifactInstall_Enter_99"),
 		"-v", "1"}
 	fakeErrWriter.Reset()
 	err = run()

--- a/awriter/writer_test.go
+++ b/awriter/writer_test.go
@@ -172,7 +172,7 @@ func TestWithScripts(t *testing.T) {
 	u := handlers.NewRootfsV1(upd)
 	updates := &Updates{U: []handlers.Composer{u}}
 
-	scr, err := ioutil.TempFile("", "ArtifactDownload_Enter_10_")
+	scr, err := ioutil.TempFile("", "ArtifactInstall_Enter_10_")
 	assert.NoError(t, err)
 	defer os.Remove(scr.Name())
 


### PR DESCRIPTION
Instead of being part of the artifact Download state script
will be together with Idle and Sync scripts part of rootfs.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>