### PR TITLE
MEN-1355: mender-artifact now fails with whitespace in the artifact-name

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -69,11 +69,6 @@ func scripts(c *cli.Context) (*artifact.Scripts, error) {
 }
 
 func writeArtifact(c *cli.Context) error {
-	if len(c.StringSlice("device-type")) == 0 ||
-		len(c.String("artifact-name")) == 0 ||
-		len(c.String("update")) == 0 {
-		return cli.NewExitError("must provide `device-type`, `artifact-name` and `update`", 1)
-	}
 
 	// set default name
 	name := "artifact.mender"
@@ -504,8 +499,18 @@ func run() error {
 	// write
 	//
 	writeRootfs := cli.Command{
-		Name:   "rootfs-image",
-		Action: writeArtifact,
+		Name: "rootfs-image",
+		Action: func(c *cli.Context) error {
+			if len(c.StringSlice("device-type")) == 0 ||
+				len(c.String("artifact-name")) == 0 ||
+				len(c.String("update")) == 0 {
+				return cli.NewExitError("must provide `device-type`, `artifact-name` and `update`", 1)
+			}
+			if len(strings.Fields(c.String("artifact-name"))) > 1 { // check for whitespace in artifact-name
+				return cli.NewExitError("whitespace is not allowed in the artifact-name", 1)
+			}
+			return writeArtifact(c)
+		},
 	}
 
 	writeRootfs.Flags = []cli.Flag{

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -111,6 +111,13 @@ func TestArtifactsWrite(t *testing.T) {
 		})
 	assert.NoError(t, err)
 
+	// no whitespace allowed in artifact-name
+	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
+		"-n", "mender-1. 1", "-u", filepath.Join(updateTestDir, "update.ext4"),
+		"-o", filepath.Join(updateTestDir, "art.mender")}
+	err = run()
+	assert.Equal(t, "whitespace is not allowed in the artifact-name", err.Error())
+
 	// store named file
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
 		"-n", "mender-1.1", "-u", filepath.Join(updateTestDir, "update.ext4"),


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>
(cherry picked from commit 544c74e203d5cbdcaf3b5556a2b466b11b6f581c)