### PR TITLE
MEN-1412 Fix broken header checksum verification.

### DIFF
--- a/artifact/checksum.go
+++ b/artifact/checksum.go
@@ -77,12 +77,8 @@ func (c *Checksum) Read(p []byte) (int, error) {
 	n, err := c.r.Read(p)
 	if err == io.EOF {
 		// verify checksum
-		sum := c.h.Sum(nil)
-		checksum := make([]byte, hex.EncodedLen(len(sum)))
-		hex.Encode(checksum, sum)
-		if !bytes.Equal(c.c, checksum) {
-			return 0, errors.Errorf("invalid checksum; expected: [%s]; actual: [%s]",
-				c.c, checksum)
+		if verErr := c.Verify(); verErr != nil {
+			return 0, verErr
 		}
 	}
 	return n, err
@@ -96,6 +92,15 @@ func (c *Checksum) Checksum() []byte {
 	checksum := make([]byte, hex.EncodedLen(len(sum)))
 	hex.Encode(checksum, sum)
 	return checksum
+}
+
+func (c *Checksum) Verify() error {
+	sum := c.Checksum()
+	if !bytes.Equal(c.c, sum) {
+		return errors.Errorf("invalid checksum; expected: [%s]; actual: [%s]",
+			c.c, sum)
+	}
+	return nil
 }
 
 type ChecksumStore struct {


### PR DESCRIPTION
For reading and verifying header checksum we are using checksum.Reader.
Internal inplementation of checksum.Reader is using io.TeeReader for
calculating checksum and reading the stream at the same time.
After receiving EOF checksum should be checked automatically inside
checksum.Reader, but if we are inside tar archive error is not passed up
the stack to tar.Reader.
The workaround is to check the sum again after the whole header is read.

Changelog: Title


Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>