### PR TITLE
MEN-1213 Fix modifying signed artifact.

### DIFF
--- a/modify_existing_test.go
+++ b/modify_existing_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -93,7 +92,6 @@ func verify(image, file, expected string) bool {
 	if err != nil {
 		return false
 	}
-	fmt.Printf("expected: [%s]; actual: [%s]\n", expected, string(data))
 	return strings.Contains(string(data), expected)
 }
 
@@ -207,10 +205,89 @@ func TestModifyServerCert(t *testing.T) {
 
 	tmpCert, err := ioutil.TempFile("", "mender-test-cert")
 	assert.NoError(t, err)
+	defer os.Remove(tmpCert.Name())
 
 	os.Args = []string{"mender-artifact", "modify",
 		"-c", tmpCert.Name(),
 		filepath.Join(tmp, "mender_test.img")}
+	err = run()
+	assert.NoError(t, err)
+}
+
+const (
+	PrivateRSAKey = `-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDSTLzZ9hQq3yBB+dMDVbKem6iav1J6opg6DICKkQ4M/yhlw32B
+CGm2ArM3VwQRgq6Q1sNSq953n5c1EO3Xcy/qTAKcXwaUNml5EhW79AdibBXZiZt8
+fMhCjUd/4ce3rLNjnbIn1o9L6pzV4CcVJ8+iNhne5vbA+63vRCnrc8QuYwIDAQAB
+AoGAQKIRELQOsrZsxZowfj/ia9jPUvAmO0apnn2lK/E07k2lbtFMS1H4m1XtGr8F
+oxQU7rLyyP/FmeJUqJyRXLwsJzma13OpxkQtZmRpL9jEwevnunHYJfceVapQOJ7/
+6Oz0pPWEq39GCn+tTMtgSmkEaSH8Ki9t32g9KuQIKBB2hbECQQDsg7D5fHQB1BXG
+HJm9JmYYX0Yk6Z2SWBr4mLO0C4hHBnV5qPCLyevInmaCV2cOjDZ5Sz6iF5RK5mw7
+qzvFa8ePAkEA46Anom3cNXO5pjfDmn2CoqUvMeyrJUFL5aU6W1S6iFprZ/YwdHcC
+kS5yTngwVOmcnT65Vnycygn+tZan2A0h7QJBAJNlowZovDdjgEpeCqXp51irD6Dz
+gsLwa6agK+Y6Ba0V5mJyma7UoT//D62NYOmdElnXPepwvXdMUQmCtpZbjBsCQD5H
+VHDJlCV/yzyiJz9+tZ5giaAkO9NOoUBsy6GvdfXWn2prXmiPI0GrrpSvp7Gj1Tjk
+r3rtT0ysHWd7l+Kx/SUCQGlitd5RDfdHl+gKrCwhNnRG7FzRLv5YOQV81+kh7SkU
+73TXPIqLESVrqWKDfLwfsfEpV248MSRou+y0O1mtFpo=
+-----END RSA PRIVATE KEY-----`
+
+	PrivateECDSAKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMOJJlcKM0sMwsOezNKeUXm4BiN6+ZPggu87yuZysDgIoAoGCCqGSM49
+AwEHoUQDQgAE9iC/hyQO1UQfw0fFj1RjEjwOvPIBsz6Of3ock/gIwmnhnC/7USo3
+yOTl4wVLQKA6mFvMV9o8B9yTBNg3mQS0vA==
+-----END EC PRIVATE KEY-----`
+)
+
+func TestModifySigned(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "mender-modify")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	err = copyFile("mender_test.img", filepath.Join(tmp, "mender_test.img"))
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "rsa.key"), []byte(PrivateRSAKey), 0711)
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "ecdsa.key"), []byte(PrivateECDSAKey), 0711)
+	assert.NoError(t, err)
+
+	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
+		"-n", "release-1", "-u", filepath.Join(tmp, "mender_test.img"),
+		"-o", filepath.Join(tmp, "artifact.mender"),
+		"-k", filepath.Join(tmp, "rsa.key")}
+	err = run()
+	assert.NoError(t, err)
+
+	os.Args = []string{"mender-artifact", "modify",
+		"-n", "release-2",
+		filepath.Join(tmp, "artifact.mender")}
+
+	err = run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"artifact is signed but no verification key was provided")
+
+	os.Args = []string{"mender-artifact", "modify",
+		"-n", "release-2",
+		"-k", filepath.Join(tmp, "rsa.key"),
+		filepath.Join(tmp, "artifact.mender")}
+
+	err = run()
+	assert.NoError(t, err)
+
+	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
+		"-n", "release-1", "-u", filepath.Join(tmp, "mender_test.img"),
+		"-o", filepath.Join(tmp, "artifact_ecdsa.mender"),
+		"-k", filepath.Join(tmp, "ecdsa.key")}
+	err = run()
+	assert.NoError(t, err)
+
+	os.Args = []string{"mender-artifact", "modify",
+		"-n", "release-2",
+		"-k", filepath.Join(tmp, "ecdsa.key"),
+		filepath.Join(tmp, "artifact_ecdsa.mender")}
+
 	err = run()
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Now it is possible to modify signed artifact. The public key is
extracted form provided private key and the artifact is validated
before it can be signed.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>