### PR TITLE
MEN-1667 Artifact version 3 format documentation

### DIFF
--- a/Documentation/artifact-format.md
+++ b/Documentation/artifact-format.md
@@ -8,6 +8,82 @@ Note that there are some restrictions on ordering of the files, described
 in the "Ordering" section.
 
 
+### version 3
+
+```
+-artifact.mender (tar format)
+  |
+  +---version
+  |
+  +---manifest
+  |
+  +---manifest.sig
+  |
+  +---manifest-augment
+  |
+  +---header.tar.gz (tar format)
+  |    |
+  |    +---header-info
+  |    |
+  |    +---scripts
+  |    |    |
+  |    |    +---State.Enter
+  |    |    +---State.Leave
+  |    |    +---State.Error
+  |    |    `---<more scripts>
+  |    |
+  |    `---headers
+  |         |
+  |         +---0000
+  |         |    |
+  |         |    +---files
+  |         |    |
+  |         |    +---type-info
+  |         |    |
+  |         |    +---meta-data
+  |         |
+  |         +---0001
+  |         |    |
+  |         |    `---<more headers>
+  |         |
+  |         `---000n ...
+  |
+  +---header-augment.tar.gz (tar format)
+  |    |
+  |    +---header-info
+  |    |
+  |    `---headers
+  |         |
+  |         +---0000
+  |         |    |
+  |         |    +---files
+  |         |    |
+  |         |    +---type-info
+  |         |    |
+  |         |    +---meta-data
+  |         |
+  |         +---0001
+  |         |    |
+  |         |    `---<more headers>
+  |         |
+  |         `---000n ...
+  |
+  `---data
+       |
+       +---0000.tar.gz
+       |    +--<image-file (ext4)>
+       |    +--<binary delta, etc>
+       |    `--...
+       |
+       +---0001.tar.gz
+       |    +--<image-file (ext4)>
+       |    +--<binary delta, etc>
+       |    `--...
+       |
+       +---000n.tar.gz ...
+            `--...
+```
+
 ### version 2
 
 ```
@@ -122,7 +198,7 @@ Contains the below content exactly:
 ```
 {
   "format": "mender",
-  "version": 2
+  "version": 3
 }
 ```
 
@@ -137,7 +213,7 @@ manifest
 Format: text
 Version: Exists only in version 2 and later
 
-Contains the file checksums, formatted exactly like below:
+Contains file checksums, formatted exactly like below:
 
 ```
 1d0b820130ae028ce8a79b7e217fe505a765ac394718e795d454941487c53d32  data/0000/update.ext4
@@ -145,7 +221,7 @@ Contains the file checksums, formatted exactly like below:
 52c76ab66947278a897c2a6df8b4d77badfa343fec7ba3b2983c2ecbbb041a35  version
 ```
 
-The manifest file contains checksums of compressed header, version and all
+The manifest file contains checksums of compressed header, version and the
 data files being a part of the artifact. The format matches the output of
 `sha256sum` tool which is the sum and the name of the file separated by
 the two spaces.
@@ -154,12 +230,34 @@ the two spaces.
 manifest.sig
 ----
 
-Format: TBD
+Format: base64 encoded ecdsa or rsa signature
 Version: Exists only in version 2 and later
 
 File containing the signature of `manifest`.
 
 It is legal for an artifact not to have signature file.
+
+
+manifest-augment
+----
+
+Format: text
+Version: Exists only in version 3 and later
+
+Contains file checksums, formatted exactly like below:
+
+```
+4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619  header-augment.tar.gz
+1d0b820130ae028ce8a79b7e217fe505a765ac394718e795d454941487c53d32  data/0000/update.delta
+```
+
+The manifest-augment file is the extension of manifest file and is needed only
+for certain types of the updates.
+It contains the checksums of the files which could change during the creation of the
+artifact and therefore which can not be signed explicitly. In case of the
+delta update this file will contain the checksum of the delta file (the actual
+payload of the file being a part of the artifact) and the header-augment.tar.gz
+file checksum.
 
 
 header.tar.gz
@@ -175,8 +273,82 @@ version is specified outside of `header.tar.gz`.
 
 Why is there a tar file inside a tar file? See the "Ordering" section.
 
+### header-info (version 3)
 
-### header-info
+Format: JSON
+
+`header-info` must be the first file within `header.tar.gz`. Its content is:
+
+```
+{
+  "updates": [
+    {
+      "type": "rootfs-image"
+    },
+    {
+      "type": "rootfs-image"
+    },
+    {
+      ...
+    }
+  ],
+  "artifact_provides": [
+          { "artifact_name": "name" },
+          { "artifact_group": "group-1" },
+          { "update_types_supported": ["rootfs-image"]},
+      ],
+  "artifact_depends": [
+          { "device_type": ["vexpress-qemu", "beaglebone"] },
+          { "artifact_name": ["rootfs-1"] },
+      ],
+  ],
+}
+```
+
+The `updates` parameter is as described in the
+section below (see the version 2 header-info description for the details).
+
+#### artifact_depends
+
+The `artifact_depends` contains a set of parameters that the current artifact
+depends on. It can contain zero or more elements (in most cases at least
+`device_type` should be present though).
+
+The given artifact will be installed, only if the device itself
+and the artifact currently installed on the device are providing a full set
+of matching parameters. The complete list contains following parameters:
+
+* `artifact_name` is the name of the artifact currently installed on the device
+* `device_type` is the type of the device (see `device_provides` below)
+* `artifact_group` is the group of the artifacts current artifact belongs to
+* `update_types_supported` is the list of the update types Mender agent installed
+on the device can handle
+* `artifact_versions_supported` is the list of the versions of the artifacts
+agent installed on the device can handle
+
+
+#### artifact_provides
+
+The `artifact_provides` is a set of global parameters given artifact provides.
+For the detailed information see the description of the given parameter below.
+
+* `artifact_name` is the name of the artifact
+* `artifact_group` is the name of the group of artifacts given artifact
+belongs to
+* `update_types_supported` is the list of all the update types given Mender
+client can install
+
+#### device_provides
+
+There is also a set of parameters that are provided by the device itself,
+which are not a part of the artifact. Those are the values, that the device
+itself can read and send to the Mender server when needed. The full list of
+`device_provides` is as follows:
+
+* `device_type` is the current device type
+
+
+### header-info (up to version 2 only)
 
 Format: JSON
 
@@ -232,8 +404,65 @@ or multiple files listed.  For example:
 { "files" : ["core-image-minimal-201608110900.ext4", "core-image-base-201608110900.ext4"]}
 ```
 
+### type-info (version 3)
 
-### type-info
+Format: JSON
+
+A file that provides information about the type of package contained within the
+tar file. The first and the only required entry is the type of the update
+corresponding to the type in `header-info` file.
+It can also contain some additional parameters extending or modifying the global
+`artifact_provides` set of parameters specific for a given update type.
+
+```
+{
+  "type": "rootfs-image"
+  "artifact_provides": [
+          { "rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619" },
+      ],
+  "artifact_depends": [
+          { "rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619" },
+      ],
+}
+```
+
+#### artifact_provides
+
+As an opposite to the list of global `artifact_provides` being a part of
+`header-info` file, the `artifact_provides` section in the `type-info` file
+is a set of parameters specific for a given update type.
+
+The list of currently supported parameters is as follows:
+
+* `rootfs_image_checksum` is the checksum of the image currently installed on the
+device
+
+#### artifact_depends
+
+The `artifact_depends` section in the `type-info` file is a set of parameters
+specific for a given update type. The list of currently supported
+parameters is as follows:
+
+* `rootfs_image_checksum` is the checksum of the image that needs to be installed
+on the device before current artifact can be installed
+
+
+### type-info (version 1 and version 2)
+
+Format: JSON
+
+A file that provides information about the type of package contained within the
+tar file. The first and the only required entry is the type of the update
+corresponding to the type in `header-info` file.
+
+```
+{
+  "type": "rootfs-image"
+
+}
+```
+
+### type-info (up to version 2 only)
 
 Format: JSON
 
@@ -332,6 +561,20 @@ For more information about the script and state API, see the official Mender
 documentation.
 
 
+header-augment.tar.gz (version 3)
+-------------
+
+Format: tar
+
+This file is complementing the information contained in the header.tar.gz.
+It can have the same structure as header.tar.gz, but for security reasons
+(this file is not signed) only certain files and parameters are allowed.
+
+At the moment ONLY header-info and type-info files are allowed which can
+contain only `artifact_depends` `rootfs_image_checksum`
+parameters and type of the update.
+
+
 data
 ----
 
@@ -366,13 +609,15 @@ Ordering
 Some ordering rules are enforced on the artifact tar file. For the outer tar
 file:
 
-| File/Directory  | Ordering rule                  |
-|-----------------|--------------------------------|
-| `version`       | First in `.mender` tar archive |
-| `manifest`      | After `version` (v2)           |
-| `manifest.sig`  | Optional after `manifest` (v2) |
-| `header.tar.gz` | After `info`                   |
-| `data`          | After `header.tar.gz`          |
+| File/Directory            | Ordering rule                       |
+|---------------------------|-------------------------------------|
+| `version`                 | First in `.mender` tar archive      |
+| `manifest`                | After `version` (v2)                |
+| `manifest.sig`            | Optional after `manifest` (v2)      |
+| `manifest-augment`        | Optional after `manifest.sig` (v3)  |
+| `header.tar.gz`           | After all manifest files            |
+| `header-augment.tar.gz`   | Optional after `header.tar.gz` (v3) |
+| `data`                    | After `header.tar.gz`               |
 
 For the embedded `header.tar.gz` file:
 


### PR DESCRIPTION
Add a new documentation for version 3 of Mender artifact.
This contains `artifact_provides` and `artifact_depends` sections
needed for updates ordering as well as some preliminary additions
for delta updates.

Changelog: Title

Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>