### PR TITLE
FIX: mender-artifact cp no longer renames the artifact.

### DIFF
--- a/cli/mender-artifact/partition.go
+++ b/cli/mender-artifact/partition.go
@@ -228,7 +228,7 @@ func (a *artifactExtFile) Close() error {
 	os.Remove(a.tmpf.Name())
 	if a.repack {
 		return repackArtifact(a.name, a.path,
-			a.key, filepath.Base(a.name))
+			a.key, "")
 	}
 	return nil
 }


### PR DESCRIPTION
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>