### PR TITLE
FIX: remove extraneous file from using mender-artifact cp. 

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -104,7 +104,7 @@ func unpackArtifact(name string) (string, error) {
 	aReader := areader.NewReader(f)
 	rootfs := handlers.NewRootfsInstaller()
 
-	tmp, err := ioutil.TempFile(filepath.Dir(name), "mender-artifact")
+	tmp, err := ioutil.TempFile("", "mender-artifact")
 	if err != nil {
 		return "", err
 	}

--- a/cli/mender-artifact/partition.go
+++ b/cli/mender-artifact/partition.go
@@ -226,6 +226,7 @@ func newArtifactExtFile(key, fpath string, p partition) (*artifactExtFile, error
 
 func (a *artifactExtFile) Close() error {
 	os.Remove(a.tmpf.Name())
+	defer os.Remove(a.path)
 	if a.repack {
 		return repackArtifact(a.name, a.path,
 			a.key, filepath.Base(a.name))


### PR DESCRIPTION
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>