### PR TITLE
Update the Go versions for testing and building artifact tool.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 # Golang version matrix
 go:
-    - 1.9.4
-    - tip
+    - 1.10
+    - 1.11
 
 install:
     # Get tools used in Makefile


### PR DESCRIPTION
Use the latest official, and one supported by Yocto Go versions for building and testing the artifact. 
Get rid of building using `tip` which is the latest Go development version.

Changelog: None

Signed-of-by: Marcin Pasinski <marcin.pasinski@northern.tech>