### PR TITLE
MEN-2155 Fail validate when key supplied for unsigned artifact

### DIFF
--- a/cli/mender-artifact/validate.go
+++ b/cli/mender-artifact/validate.go
@@ -33,6 +33,7 @@ func validate(art io.Reader, key []byte) error {
 	// just continue checking consistency and return info if
 	// signature verification failed
 	var validationError error
+	verifiedDigitalSignature := false
 	verify := func(message, sig []byte) error {
 		verifyCallback := func(message, sig []byte) error {
 			return errors.New("artifact is signed but no verification key was provided")
@@ -45,6 +46,8 @@ func validate(art io.Reader, key []byte) error {
 		if verifyCallback != nil {
 			if err := verifyCallback(message, sig); err != nil {
 				validationError = err
+			} else {
+				verifiedDigitalSignature = true
 			}
 		}
 		return nil
@@ -57,6 +60,10 @@ func validate(art io.Reader, key []byte) error {
 	}
 	if validationError != nil {
 		Log.Debugf("error validating signature: %s", validationError.Error())
+		return ErrInvalidSignature
+	}
+	if key != nil && !verifiedDigitalSignature {
+		Log.Debug("key was specified but no digital signature was found")
 		return ErrInvalidSignature
 	}
 	return nil

--- a/cli/mender-artifact/validate_test.go
+++ b/cli/mender-artifact/validate_test.go
@@ -72,6 +72,8 @@ var validateTests = []struct {
 		ErrInvalidSignature},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKeyInvalid),
 		ErrInvalidSignature},
+	{2, []byte(PrivateValidateRSAKey), nil, ErrInvalidSignature},
+	{2, nil, []byte(PublicValidateRSAKey), ErrInvalidSignature}, // MEN-2155
 }
 
 func TestValidate(t *testing.T) {
@@ -83,6 +85,7 @@ func TestValidate(t *testing.T) {
 		if test.expectedError == nil {
 			assert.NoError(t, err)
 		} else {
+			assert.Error(t, err)
 			assert.Contains(t, err.Error(), test.expectedError.Error())
 		}
 		fmt.Println("---------------------------------")


### PR DESCRIPTION
Changelog: A command of the form
"mender-artifact validate unsigned.mender -k public.key"
was incorrectly succeeding for an unsigned artifact when a public key
was supplied. Supplying a public key indicates that the caller requires
the artifact to contain a signature that matches that key.
Now this command fails (exits with a nonzero value) as expected.

Fixed logic in validate function to return an error when
a public key was given but we never received a callback to
validate a signature inside the artifact.

Added 2 more unit tests:

- Must fail validation of an unsigned artifact with key given.
  Confirmed this test failed before the fix mentioned above,
  and now passes.

- Must fail validation of a signed artifact with no key given.
  This test already, and still, passes.  It's just nice to have.

Changed TestValidate function to assert that the error is not nil
before asserting that it contains the expected text.
This makes a failure easier to understand when the error is
incorrectly nil, because it shows the line number of the assert
failure, instead of causing a panic before the assert is entered.
This happened to me when I ran the unit tests before fixing MEN-2155
and made it less obvious what was wrong.

Signed-off-by: Don Cross <cosinekitty@gmail.com>