### PR TITLE
MEN-2155 Fail validate when key supplied for unsigned artifact

### DIFF
--- a/cli/mender-artifact/validate_test.go
+++ b/cli/mender-artifact/validate_test.go
@@ -72,6 +72,8 @@ var validateTests = []struct {
 		ErrInvalidSignature},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKeyInvalid),
 		ErrInvalidSignature},
+	{2, []byte(PrivateValidateRSAKey), nil, ErrInvalidSignature},
+	{2, nil, []byte(PublicValidateRSAKey), ErrInvalidSignature}, // MEN-2155
 }
 
 func TestValidate(t *testing.T) {
@@ -83,6 +85,7 @@ func TestValidate(t *testing.T) {
 		if test.expectedError == nil {
 			assert.NoError(t, err)
 		} else {
+			assert.Error(t, err)
 			assert.Contains(t, err.Error(), test.expectedError.Error())
 		}
 		fmt.Println("---------------------------------")


### PR DESCRIPTION
Changelog: A command of the form
"mender-artifact validate unsigned.mender -k public.key"
was incorrectly succeeding for an unsigned artifact when a public key
was supplied. Supplying a public key indicates that the caller requires
the artifact to contain a signature that matches that key.
Now this command fails (exits with a nonzero value) as expected.

Fixed logic in validate function to return an error when
a public key was given but we never received a callback to
validate a signature inside the artifact.

Also fixed a problem where some callers (for example,
the new "cat" command) call validate with "" instead
of nil to indicate a missing key.

Added 2 more unit tests:

- Must fail validation of an unsigned artifact with key given.
  Confirmed this test failed before the fix mentioned above,
  and now passes.

- Must fail validation of a signed artifact with no key given.
  This test already, and still, passes.  It's just nice to have.

Changed TestValidate function to assert that the error is not nil
before asserting that it contains the expected text.
This makes a failure easier to understand when the error is
incorrectly nil, because it shows the line number of the assert
failure, instead of causing a panic before the assert is entered.
This happened to me when I ran the unit tests before fixing MEN-2155
and made it less obvious what was wrong.

Signed-off-by: Don Cross <cosinekitty@gmail.com>