### PR TITLE
Tell git to ignore Visual Studio Code directory ".vscode"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.vscode
 
 # Architecture specific extensions/prefixes
 *.[568vq]


### PR DESCRIPTION
Changelog: None

Microsoft Visual Studio Code creates a .vscode directory
to hold user settings and other things that don't belong
in source control.  Updated .gitignore to ignore this directory.

Signed-off-by: Don Cross <cosinekitty@gmail.com>