### PR TITLE
MEN-2169 Fix mender-artifact "cat", "cp", "modify" on signed artifacts.

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -104,7 +104,7 @@ func unpackArtifact(name string) (string, error) {
 	aReader := areader.NewReader(f)
 	rootfs := handlers.NewRootfsInstaller()
 
-	tmp, err := ioutil.TempFile(filepath.Dir(name), "mender-artifact")
+	tmp, err := ioutil.TempFile("", "mender-artifact")
 	if err != nil {
 		return "", err
 	}

--- a/cli/mender-artifact/validate_test.go
+++ b/cli/mender-artifact/validate_test.go
@@ -72,7 +72,7 @@ var validateTests = []struct {
 		ErrInvalidSignature},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKeyInvalid),
 		ErrInvalidSignature},
-	{2, []byte(PrivateValidateRSAKey), nil, ErrInvalidSignature},
+	{2, []byte(PrivateValidateRSAKey), nil, nil},
 	{2, nil, []byte(PublicValidateRSAKey), ErrInvalidSignature}, // MEN-2155
 }
 


### PR DESCRIPTION
Changelog: Fixed a bug that caused a command like
"mender-artifact cat signed.mender:/etc/mender/artifact_info"
to fail with the error:
"failed to open the partition reader: err: error validating signature"
There was a similar problem with the "cp" command, and also
the "modify" command when no "-k" was present to replace the
existing signature.

This change is based on the general idea that if the user
does not specify a public key, he is saying he does not want
to authenticate a digital signature, whether or not one exists
in the artifact.

Simplified the validate function so it no longer returns an
error if the artifact contains a signature but no public
key was specified by the caller.

Added a unit test that used to fail before the bug was fixed,
and now it passes.

Updated existing unit tests that were affected by this change.

Signed-off-by: Don Cross <cosinekitty@gmail.com>