### PR TITLE
FIX: mender-artifact cat,cp,modify etc no longer removes the update.

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -104,7 +104,7 @@ func unpackArtifact(name string) (string, error) {
 	aReader := areader.NewReader(f)
 	rootfs := handlers.NewRootfsInstaller()
 
-	tmp, err := ioutil.TempFile(filepath.Dir(name), "mender-artifact")
+	tmp, err := ioutil.TempFile("", "mender-artifact")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Previously an update present in a directory, with the same name as the
update present in an update would be removed as a result of what the
functions thought was tmp-files.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>