### PR TITLE
[2.3.x] FIX: mender-artifact cat,cp,modify etc no longer removes the update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 # Golang version matrix
 go:
-    - 1.9.4
-    - tip
+    - 1.10.4
+    - 1.11
 
 install:
     # Get tools used in Makefile

--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -104,7 +104,7 @@ func unpackArtifact(name string) (string, error) {
 	aReader := areader.NewReader(f)
 	rootfs := handlers.NewRootfsInstaller()
 
-	tmp, err := ioutil.TempFile(filepath.Dir(name), "mender-artifact")
+	tmp, err := ioutil.TempFile("", "mender-artifact")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Previously an update present in a directory, with the same name as the
update present in an update would be removed as a result of what the
functions thought was tmp-files.

MEN-2171

Changelog: Commit

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>
(cherry picked from commit 78544a96c18a5e81cb7bc141c918e08646c70ced)