### PR TITLE
Increase gycyclo limit to allow error checking in simple functions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PKGNAME = mender-artifact
 PKGFILES = $(shell find . \( -path ./vendor -o -path ./Godeps \) -prune \
 		-o -type f -name '*.go' -print)
 PKGFILES_notest = $(shell echo $(PKGFILES) | tr ' ' '\n' | grep -v _test.go)
-GOCYCLO ?= 15
+GOCYCLO ?= 20
 
 CGO_ENABLED=1
 export CGO_ENABLED


### PR DESCRIPTION
This should be considered a temporary measure, and a better method
should be considered later, such as not including simple "check error
and return" branches in the gocyclo count, since this is needed
*everywhere* in Go code.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>