### PR TITLE
Add support for compressing artifacts using LZMA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 install:
     # Get tools used in Makefile
     - make get-tools
-    - sudo apt-get install mtools
+    - sudo apt-get install mtools liblzma-dev
 
 before_script:
     # Print build info.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -9,6 +9,7 @@ ceb1b36ff073bd13d9806d4615b931707768ca9023805620acc32dd1cfc2f680  vendor/github.
 2eb550be6801c1ea434feba53bf6d12e7c71c90253e0a9de4a4f46cf88b56477  vendor/github.com/pmezard/go-difflib/LICENSE
 2d36597f7117c38b006835ae7f537487207d8ec407aa9d9980794b2030cbc067  vendor/golang.org/x/sys/LICENSE
 2d36597f7117c38b006835ae7f537487207d8ec407aa9d9980794b2030cbc067  vendor/golang.org/x/crypto/LICENSE
+a284e538f3e5649ae6a8f32da2bbd18e9daabf2c1ebbfb99ed92e797b159be1a  vendor/github.com/mendersoftware/go-liblzma/LICENSE
 #
 # ISC licenses.
 3525392c6db3b804af76980b2c560ee9ec1abdadd907d76a26091df7c78f3a25  vendor/github.com/davecgh/go-spew/LICENSE

--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -312,10 +312,11 @@ func writeDataFile(t *testing.T, name, data string) io.Reader {
 	comp := artifact.NewCompressorGzip()
 
 	buf := bytes.NewBuffer(nil)
-	gz := comp.NewWriter(buf)
+	gz, err := comp.NewWriter(buf)
+	assert.NoError(t, err)
 	tw := tar.NewWriter(gz)
 	sw := artifact.NewTarWriterStream(tw)
-	err := sw.Write([]byte(data), name)
+	err = sw.Write([]byte(data), name)
 	assert.NoError(t, err)
 	err = tw.Close()
 	assert.NoError(t, err)

--- a/artifact/compressor_gzip_test.go
+++ b/artifact/compressor_gzip_test.go
@@ -27,7 +27,8 @@ func TestCompressorGzip(t *testing.T) {
 	assert.Equal(t, c.GetFileExtension(), ".gz")
 
 	buf := bytes.NewBuffer(nil)
-	w := c.NewWriter(buf)
+	w, err := c.NewWriter(buf)
+	assert.NoError(t, err)
 
 	i, err := w.Write([]byte(testData))
 	assert.NoError(t, err)

--- a/artifact/compressor_lzma.go
+++ b/artifact/compressor_lzma.go
@@ -11,34 +11,35 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+// +build !nolzma
 
 package artifact
 
 import (
-	"compress/gzip"
+	"github.com/mendersoftware/go-liblzma"
 	"io"
 )
 
-type CompressorGzip struct {
+type CompressorLzma struct {
 	c Compressor
 }
 
-func NewCompressorGzip() Compressor {
-	return &CompressorGzip{}
+func NewCompressorLzma() Compressor {
+	return &CompressorLzma{}
 }
 
-func (c *CompressorGzip) GetFileExtension() string {
-	return ".gz"
+func (c *CompressorLzma) GetFileExtension() string {
+	return ".xz"
 }
 
-func (c *CompressorGzip) NewReader(r io.Reader) (io.ReadCloser, error) {
-	return gzip.NewReader(r)
+func (c *CompressorLzma) NewReader(r io.Reader) (io.ReadCloser, error) {
+	return xz.NewReader(r)
 }
 
-func (c *CompressorGzip) NewWriter(w io.Writer) (io.WriteCloser, error) {
-	return gzip.NewWriter(w), nil
+func (c *CompressorLzma) NewWriter(w io.Writer) (io.WriteCloser, error) {
+	return xz.NewWriter(w, xz.Level9)
 }
 
 func init() {
-	RegisterCompressor("gzip", &CompressorGzip{})
+	RegisterCompressor("lzma", &CompressorLzma{})
 }

--- a/artifact/compressor_none.go
+++ b/artifact/compressor_none.go
@@ -60,8 +60,12 @@ func (c *CompressorNone) NewReader(r io.Reader) (io.ReadCloser, error) {
 	}, nil
 }
 
-func (c *CompressorNone) NewWriter(w io.Writer) io.WriteCloser {
+func (c *CompressorNone) NewWriter(w io.Writer) (io.WriteCloser, error) {
 	return &compressor_none_writer{
 		w: w,
-	}
+	}, nil
+}
+
+func init() {
+	RegisterCompressor("none", &CompressorNone{})
 }

--- a/artifact/compressor_none_test.go
+++ b/artifact/compressor_none_test.go
@@ -26,7 +26,8 @@ func TestCompressorNone(t *testing.T) {
 	assert.Equal(t, c.GetFileExtension(), "")
 
 	buf := bytes.NewBuffer(nil)
-	w := c.NewWriter(buf)
+	w, err := c.NewWriter(buf)
+	assert.NoError(t, err)
 
 	i, err := w.Write([]byte(testData))
 	assert.NoError(t, err)

--- a/artifact/compressor_test.go
+++ b/artifact/compressor_test.go
@@ -46,7 +46,19 @@ func TestCompressorFromFileName(t *testing.T) {
 	assert.NoError(t, err, nil)
 	assert.Equal(t, c.GetFileExtension(), "")
 
-	c, err = NewCompressorFromFileName("file.tar.xz")
+	c, err = NewCompressorFromFileName("file.tar.foo")
 	assert.NoError(t, err, nil)
 	assert.Equal(t, c.GetFileExtension(), "")
+}
+
+func TestRegisteredCompressors(t *testing.T) {
+	compressorIds := GetRegisteredCompressorIds()
+
+	// Verify the list contains all non-optional compressors
+	assert.True(t, len(compressorIds) >= 2)
+	assert.Contains(t, compressorIds, "none")
+	assert.Contains(t, compressorIds, "gzip")
+
+	// Verify 'none' is at the beginning of the list
+	assert.Equal(t, "none", compressorIds[0])
 }

--- a/awriter/writer.go
+++ b/awriter/writer.go
@@ -86,7 +86,10 @@ func writeTempHeader(c artifact.Compressor, s *artifact.ChecksumStore, devices [
 	// use function to make sure to close gz and tar before
 	// calculating checksum
 	err = func() error {
-		gz := c.NewWriter(ch)
+		gz, err := c.NewWriter(ch)
+		if err != nil {
+			return errors.Wrapf(err, "writer: can not open compressor")
+		}
 		defer gz.Close()
 
 		htw := tar.NewWriter(gz)

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"fmt"
+	"github.com/mendersoftware/mender-artifact/artifact"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -229,12 +232,13 @@ func run() error {
 		},
 	}
 
+	compressors := artifact.GetRegisteredCompressorIds()
 	globalFlags := []cli.Flag{
 		cli.StringFlag{
 			Name:  "compression",
 			Value: "gzip",
-			Usage: "Compression to use for data and header inside the artifact, "+
-				"currently supports:  none, gzip.",
+			Usage: fmt.Sprintf("Compression to use for data and header inside the artifact, "+
+				"currently supports: %v.", strings.Join(compressors, ", ")),
 		},
 	}
 

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -156,7 +156,10 @@ func (rfs *Rootfs) ComposeData(tw *tar.Writer, no int) error {
 	defer os.Remove(f.Name())
 
 	err := func() error {
-		gz := rfs.update.Compressor.NewWriter(f)
+		gz, err := rfs.update.Compressor.NewWriter(f)
+		if err != nil {
+			return errors.Wrapf(err, "update: can not open compressor: %v", rfs.update)
+		}
 		defer gz.Close()
 
 		tarw := tar.NewWriter(gz)

--- a/vendor/github.com/mendersoftware/go-liblzma/LICENSE
+++ b/vendor/github.com/mendersoftware/go-liblzma/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2011-2012 Rémy Oudompheng. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * The name of Rémy Oudompheng may not be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/vendor/github.com/mendersoftware/go-liblzma/enums.go
+++ b/vendor/github.com/mendersoftware/go-liblzma/enums.go
@@ -1,0 +1,121 @@
+// Copyright 2012 Rémy Oudompheng. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package go-liblzma is a wrapper for liblzma and XZ file format.
+package xz
+
+const DefaultBufsize = 32768
+
+type Action uint
+
+const (
+	// Continue coding.
+	Run Action = iota
+	// Make all the input available at output.
+	SyncFlush
+	// Finish encoding of the current Block.
+	FullFlush
+	// Finish the coding operation.
+	Finish
+)
+
+type Errno uint
+
+var _ error = Errno(0)
+
+const (
+	// Operation completed successfully.
+	Ok Errno = iota
+	// End of stream was reached.
+	StreamEnd
+	// Input stream has no integrity check.
+	NoCheck
+	// Cannot calculate the integrity check.
+	UnsupportedCheck
+	// Integrity check type is now available.
+	GetCheck
+	// Cannot allocate memory.
+	MemError
+	// Memory usage limit was reached.
+	MemlimitError
+	// File format not recognized.
+	FormatError
+	// Invalid or unsupported options.
+	OptionsError
+	// Data is corrupt.
+	DataError
+	// No progress is possible.
+	BufError
+	// Programming error.
+	ProgError
+)
+
+var errorMsg = [...]string{
+	"Operation completed successfully",
+	"End of stream was reached",
+	"Input stream has no integrity check",
+	"Cannot calculate the integrity check",
+	"Integrity check type is now available",
+	"Cannot allocate memory",
+	"Memory usage limit was reached",
+	"File format not recognized",
+	"Invalid or unsupported options",
+	"Data is corrupt",
+	"No progress is possible",
+	"Programming error",
+}
+
+func (e Errno) Error() string {
+	return errorMsg[e]
+}
+
+type Checksum uint
+
+const (
+	CheckNone   Checksum = 0
+	CheckCRC32  Checksum = 1
+	CheckCRC64  Checksum = 4
+	CheckSHA256 Checksum = 10
+)
+
+type Preset uint32
+
+const (
+	Level0 Preset = iota
+	Level1
+	Level2
+	Level3
+	Level4
+	Level5
+	Level6
+	Level7
+	Level8
+	Level9
+)
+
+const (
+	// Default compression preset.
+	LevelDefault Preset = Level6
+	// Extreme compression preset. To be OR'ed with another preset.
+	LevelExtreme Preset = 1 << 31
+	// Mask for preset level. To AND with a Preset to extract the level.
+	LevelMask Preset = 0x1f
+)
+
+// Flags passed to liblzma stream decoder constructors.
+// See liblzma/src/liblzma/api/lzma/container.h.
+const (
+	// tellNoCheck causes lzma_code to return NoCheck if the input stream has
+	// no integrity check.
+	tellNoCheck = 1 << iota
+	// tellUnsupportedCheck causes lzma_code to return UnsupportedCheck if the
+	// type of the input stream's integrity check is not supported by this
+	// version of liblzma.
+	tellUnsupportedCheck
+	// tellAnyCheck causes lzma_code to return GetCheck as soon as the type of
+	// the input stream's integrity check is known.
+	tellAnyCheck
+	// concatenated enables decoding of concatenated compressed files.
+	concatenated
+)

--- a/vendor/github.com/mendersoftware/go-liblzma/reader.go
+++ b/vendor/github.com/mendersoftware/go-liblzma/reader.go
@@ -1,0 +1,99 @@
+// Copyright 2012 Rémy Oudompheng. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xz
+
+/*
+#cgo LDFLAGS: -llzma
+#include <lzma.h>
+#include <stdlib.h>
+
+int go_lzma_code(
+    lzma_stream* handle,
+    void* next_in,
+    void* next_out,
+    lzma_action action
+) {
+    handle->next_in = next_in;
+    handle->next_out = next_out;
+    return lzma_code(handle, action);
+}
+*/
+import "C"
+
+import (
+	"io"
+	"math"
+	"unsafe"
+)
+
+type Decompressor struct {
+	handle *C.lzma_stream
+	rd     io.Reader
+	buffer []byte // buffer allocated when the Decompressor was created to hold data read from rd
+	offset int    // offset of the next byte in the buffer to read
+	length int    // number of actual bytes in the buffer from the reader
+}
+
+var _ io.ReadCloser = &Decompressor{}
+
+func NewReader(r io.Reader) (*Decompressor, error) {
+	dec := new(Decompressor)
+	dec.rd = r
+	dec.buffer = make([]byte, DefaultBufsize)
+	dec.offset = DefaultBufsize
+	dec.handle = allocLzmaStream(dec.handle)
+	// Initialize decoder
+	ret := C.lzma_auto_decoder(dec.handle, math.MaxUint64, concatenated)
+	if Errno(ret) != Ok {
+		return nil, Errno(ret)
+	}
+
+	return dec, nil
+}
+
+func (r *Decompressor) Read(out []byte) (out_count int, er error) {
+	if r.offset >= r.length {
+		n, err := r.rd.Read(r.buffer)
+
+		if err != nil && err != io.EOF {
+			return 0, err
+		}
+		r.offset, r.length = 0, n
+		r.handle.avail_in = C.size_t(n)
+	}
+	r.handle.avail_out = C.size_t(len(out))
+	action := Run
+	if r.handle.avail_in == 0 {
+		action = Finish
+	}
+	ret := C.go_lzma_code(
+		r.handle,
+		unsafe.Pointer(&r.buffer[r.offset]),
+		unsafe.Pointer(&out[0]),
+		C.lzma_action(action),
+	)
+	r.offset = r.length - int(r.handle.avail_in)
+	switch Errno(ret) {
+	case Ok:
+		er = nil
+	case StreamEnd:
+		er = io.EOF
+	default:
+		er = Errno(ret)
+	}
+
+	return len(out) - int(r.handle.avail_out), er
+}
+
+// Frees any resources allocated by liblzma. It does not close the
+// underlying reader.
+func (r *Decompressor) Close() error {
+	if r != nil {
+		C.lzma_end(r.handle)
+		C.free(unsafe.Pointer(r.handle))
+		r.handle = nil
+	}
+	return nil
+}

--- a/vendor/github.com/mendersoftware/go-liblzma/writer.go
+++ b/vendor/github.com/mendersoftware/go-liblzma/writer.go
@@ -1,0 +1,141 @@
+// Copyright 2012 Rémy Oudompheng. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xz
+
+/*
+#cgo LDFLAGS: -llzma
+#include <lzma.h>
+#include <stdlib.h>
+int go_lzma_code(
+    lzma_stream* handle,
+    void* next_in,
+    void* next_out,
+    lzma_action action
+);
+*/
+import "C"
+import (
+	"bytes"
+	"io"
+	"unsafe"
+)
+
+type Compressor struct {
+	handle *C.lzma_stream
+	writer io.Writer
+	buffer []byte
+}
+
+var _ io.WriteCloser = &Compressor{}
+
+func allocLzmaStream(t *C.lzma_stream) *C.lzma_stream {
+	return (*C.lzma_stream)(C.calloc(1, (C.size_t)(unsafe.Sizeof(*t))))
+}
+
+func NewWriter(w io.Writer, preset Preset) (*Compressor, error) {
+	enc := new(Compressor)
+	// The zero lzma_stream is the same thing as LZMA_STREAM_INIT.
+	enc.writer = w
+	enc.buffer = make([]byte, DefaultBufsize)
+	enc.handle = allocLzmaStream(enc.handle)
+	// Initialize encoder
+	ret := C.lzma_easy_encoder(enc.handle, C.uint32_t(preset), C.lzma_check(CheckCRC64))
+	if Errno(ret) != Ok {
+		return nil, Errno(ret)
+	}
+
+	return enc, nil
+}
+
+// Initializes a XZ encoder with additional settings.
+func NewWriterCustom(w io.Writer, preset Preset, check Checksum, bufsize int) (*Compressor, error) {
+	enc := new(Compressor)
+	// The zero lzma_stream is the same thing as LZMA_STREAM_INIT.
+	enc.writer = w
+	enc.buffer = make([]byte, bufsize)
+	enc.handle = allocLzmaStream(enc.handle)
+
+	// Initialize encoder
+	ret := C.lzma_easy_encoder(enc.handle, C.uint32_t(preset), C.lzma_check(check))
+	if Errno(ret) != Ok {
+		return nil, Errno(ret)
+	}
+
+	return enc, nil
+}
+
+func (enc *Compressor) Write(in []byte) (n int, er error) {
+	for n < len(in) {
+		enc.handle.avail_in = C.size_t(len(in) - n)
+		enc.handle.avail_out = C.size_t(len(enc.buffer))
+		ret := C.go_lzma_code(
+			enc.handle,
+			unsafe.Pointer(&in[n]),
+			unsafe.Pointer(&enc.buffer[0]),
+			C.lzma_action(Run),
+		)
+		switch Errno(ret) {
+		case Ok:
+			break
+		default:
+			er = Errno(ret)
+		}
+
+		n = len(in) - int(enc.handle.avail_in)
+		// Write back result.
+		produced := len(enc.buffer) - int(enc.handle.avail_out)
+		_, er = enc.writer.Write(enc.buffer[:produced])
+		if er != nil {
+			// Short write.
+			return
+		}
+	}
+	return
+}
+
+func (enc *Compressor) Flush() error {
+	enc.handle.avail_in = 0
+
+	for {
+		enc.handle.avail_out = C.size_t(len(enc.buffer))
+		// If Flush is invoked after Write produced an error, avail_in and next_in will point to
+		// the bytes previously provided to Write, which may no longer be valid.
+		enc.handle.avail_in = 0
+		ret := C.go_lzma_code(
+			enc.handle,
+			nil,
+			unsafe.Pointer(&enc.buffer[0]),
+			C.lzma_action(Finish),
+		)
+
+		// Write back result.
+		produced := len(enc.buffer) - int(enc.handle.avail_out)
+		to_write := bytes.NewBuffer(enc.buffer[:produced])
+		_, er := io.Copy(enc.writer, to_write)
+		if er != nil {
+			// Short write.
+			return er
+		}
+
+		if Errno(ret) == StreamEnd {
+			return nil
+		}
+	}
+}
+
+// Frees any resources allocated by liblzma. It does not close the
+// underlying reader.
+func (enc *Compressor) Close() error {
+	if enc != nil {
+		er := enc.Flush()
+		C.lzma_end(enc.handle)
+		C.free(unsafe.Pointer(enc.handle))
+		enc.handle = nil
+		if er != nil {
+			return er
+		}
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -13,6 +13,12 @@
 			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 		},
 		{
+			"checksumSHA1": "Uh9wFcTmKv1Y91zro3XPdKr0z1M=",
+			"path": "github.com/mendersoftware/go-liblzma",
+			"revision": "7c43a54b162c2031114bdeb3be8d64e3f507e73b",
+			"revisionTime": "2018-12-18T07:42:49Z"
+		},
+		{
 			"checksumSHA1": "8VREmaKpYjppYOd/OEl0RN5VEdU=",
 			"path": "github.com/mendersoftware/mendertesting",
 			"revision": "1c608df9fa68d7be58a8abeb4ff6911cd026ffec",


### PR DESCRIPTION
This depends on PR #150, which I have merged into this PR for the time being. Other than that I think it should be good to go. I don't have any hardware to hand so I can't test a real deployment, but the CLI tool can read the artifact back so I can't see any reason why it wouldn't work.