### PR TITLE
FIX: executeCommand failed to return an error if a command failed.

### DIFF
--- a/cli/mender-artifact/debugfs.go
+++ b/cli/mender-artifact/debugfs.go
@@ -140,7 +140,7 @@ func executeCommand(cmdstr, image string) error {
 	if len(loc) == 0 {
 		return fmt.Errorf("debugfs: prompt not found in: %s", string(data))
 	}
-	datastr := string(data[loc[1]-1]) // Strip debugfs: (version) ...
+	datastr := string(data[loc[1]-1:]) // Strip debugfs: (version) ...
 	if len(datastr) > 1 {
 		return fmt.Errorf("debugfs: error running command: %q, err: %s", cmdstr, datastr)
 	}

--- a/cli/mender-artifact/debugfs_test.go
+++ b/cli/mender-artifact/debugfs_test.go
@@ -14,8 +14,13 @@
 
 package main
 
-import "testing"
-import "github.com/stretchr/testify/assert"
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestFsck(t *testing.T) {
 	err := debugfsRunFsck("mender_test.img.broken")
@@ -23,4 +28,23 @@ func TestFsck(t *testing.T) {
 
 	err = debugfsRunFsck("mender_test.img")
 	assert.NoError(t, err)
+}
+
+func TestExecuteCommand(t *testing.T) {
+	tests := map[string]struct {
+		cmd      string
+		expected string
+	}{
+		"non-existing directory": {
+			cmd:      "cd /mender",
+			expected: "File not found by ext2_lookup",
+		},
+	}
+
+	for name, test := range tests {
+		err := executeCommand(test.cmd, "mender_test.img")
+		t.Log(name)
+		fmt.Fprintf(os.Stderr, "err: %s\n", err)
+		assert.Contains(t, err.Error(), test.expected, "Unexpected error")
+	}
 }


### PR DESCRIPTION
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>