### PR TITLE
FIX: mender-artifact cat now cleans up resources on write-errors.

### DIFF
--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -41,11 +41,12 @@ func Cat(c *cli.Context) (err error) {
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("failed to open the partition reader: err: %v", err), 1)
 	}
+	defer r.Close()
 	var w io.WriteCloser = os.Stdout
 	if _, err = io.Copy(w, r); err != nil {
 		return cli.NewExitError(fmt.Sprintf("failed to copy from: %s to stdout: err: %v", c.Args().First(), err), 1)
 	}
-	return r.Close()
+	return nil
 }
 
 func Copy(c *cli.Context) (err error) {


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>