### PR TITLE
MEN-761: Added a cgo tag to the lzma compressor.

### DIFF
--- a/artifact/compressor_lzma.go
+++ b/artifact/compressor_lzma.go
@@ -11,13 +11,14 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// +build !nolzma
+// +build !nolzma,cgo
 
 package artifact
 
 import (
-	"github.com/mendersoftware/go-liblzma"
 	"io"
+
+	"github.com/mendersoftware/go-liblzma"
 )
 
 type CompressorLzma struct {


### PR DESCRIPTION
As the lzma compressor is dependent upon go-liblzma, which has a cgo dependency,
this will not build when cgo is disabled.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>