### PR TITLE
MEN-2331: Add rm functionality to mender-artifact.

### DIFF
--- a/cli/mender-artifact/debugfs_test.go
+++ b/cli/mender-artifact/debugfs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ func TestExecuteCommand(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		err := executeCommand(test.cmd, "mender_test.img")
+		_, err := executeCommand(test.cmd, "mender_test.img")
 		t.Log(name)
 		fmt.Fprintf(os.Stderr, "err: %s\n", err)
 		assert.Contains(t, err.Error(), test.expected, "Unexpected error")

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -212,6 +212,20 @@ func run() error {
 		Action:      Copy,
 	}
 
+	remove := cli.Command{
+		Name:        "rm",
+		Usage:       "rm [artifact|sdimg|uefiimg]:<filepath>",
+		Description: "Removes the given file or directory from an Artifact or sdimg.",
+		Action:      Remove,
+	}
+
+	remove.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "recursive, r",
+			Usage: "remove directories and their contents recursively",
+		},
+	}
+
 	cat := cli.Command{
 		Name:        "cat",
 		Usage:       "cat [artifact|sdimg|uefiimg]:<filepath>",
@@ -252,6 +266,7 @@ func run() error {
 		copy,
 		cat,
 		install,
+		remove,
 	}
 	app.Flags = append([]cli.Flag{}, globalFlags...)
 	return app.Run(os.Args)


### PR DESCRIPTION
Changelog: mender-artifact tool now supports removing a file in either an sdimg,
or in a Mender Artifact, with the rm command.

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>