### PR TITLE
Updated code-coverage in rootfs_image.go

### DIFF
--- a/artifact/tar_writer_stream.go
+++ b/artifact/tar_writer_stream.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ func NewTarWriterStream(w *tar.Writer) *StreamArchiver {
 }
 
 func (str *StreamArchiver) Write(data []byte, archivePath string) error {
+	if str.Writer == nil {
+		return errors.New("arch: Can not write to empty tar-writer")
+	}
 	hdr := &tar.Header{
 		Name: archivePath,
 		Mode: 0600,

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -184,6 +184,9 @@ func match(pattern, name string) bool {
 }
 
 func writeFiles(tw *tar.Writer, updFiles []string, dir string) error {
+	if tw == nil {
+		return errors.New("writer: tar-writer is nil")
+	}
 	files := new(artifact.Files)
 	for _, u := range updFiles {
 		files.FileList = append(files.FileList, u)

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -306,8 +306,10 @@ func (rfs *Rootfs) ComposeHeader(args *ComposeHeaderArgs) error {
 			dir:        path,
 			typeinfov3: args.TypeInfoV3,
 		}); err != nil {
-			return errors.Wrap(err, "ComposeHeader: ")
+			return errors.Wrap(err, "ComposeHeader")
 		}
+	default:
+		return fmt.Errorf("ComposeHeader: rootfs-version %d not supported", rfs.version)
 
 	}
 


### PR DESCRIPTION
Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>