### PR TITLE
Use GetBinaryPath helper to search PATH and sbin

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/awriter"
 	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/mendersoftware/mender-artifact/utils"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -257,7 +258,7 @@ func repackArtifact(comp artifact.Compressor, artifact, rootfs, key, newName str
 }
 
 func processSdimg(image string) ([]partition, error) {
-	out, err := exec.Command("parted", image, "unit s", "print").Output()
+	out, err := exec.Command(utils.GetBinaryPath("parted"), image, "unit s", "print").Output()
 	if err != nil {
 		return nil, errors.Wrap(err, "can not execute `parted` command or image is broken; "+
 			"make sure parted is available in your system and is in the $PATH")

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/mendersoftware/mender-artifact/areader"
 	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -246,13 +247,13 @@ func TestCopy(t *testing.T) {
 				switch pf.(type) {
 				case *artifactExtFile:
 					imgpath := pf.(*artifactExtFile).path
-					cmd := exec.Command("debugfs", "-R", "stat /etc/mender/testkey.key", imgpath)
+					cmd := exec.Command(utils.GetBinaryPath("debugfs"), "-R", "stat /etc/mender/testkey.key", imgpath)
 					out, err := cmd.CombinedOutput()
 					require.Nil(t, err)
 					require.True(t, strings.Contains(string(out), "Mode:  0600"))
 				case sdimgFile:
 					imgpath := pf.(sdimgFile)[0].(*extFile).path
-					cmd := exec.Command("debugfs", "-R", "stat /etc/mender/testkey.key", imgpath)
+					cmd := exec.Command(utils.GetBinaryPath("debugfs"), "-R", "stat /etc/mender/testkey.key", imgpath)
 					out, err := cmd.CombinedOutput()
 					require.Nil(t, err)
 					require.True(t, strings.Contains(string(out), "Mode:  0600"))

--- a/cli/mender-artifact/debugfs.go
+++ b/cli/mender-artifact/debugfs.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/mendersoftware/mender-artifact/utils"
 	"github.com/pkg/errors"
 )
 
@@ -66,7 +67,7 @@ func debugfsCopyFile(file, image string) (string, error) {
 
 	dumpCmd := fmt.Sprintf("dump %s %s", file,
 		filepath.Join(tmpDir, filepath.Base(file)))
-	cmd := exec.Command("debugfs", "-R", dumpCmd, image)
+	cmd := exec.Command(utils.GetBinaryPath("debugfs"), "-R", dumpCmd, image)
 	ep, err := cmd.StderrPipe()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open stderr pipe of command")
@@ -173,7 +174,7 @@ func executeCommand(cmdstr, image string) (stdout *bytes.Buffer, err error) {
 	if err = scr.Close(); err != nil {
 		return nil, errors.Wrap(err, "debugfs: close sync script")
 	}
-	cmd := exec.Command("debugfs", "-w", "-f", scr.Name(), image)
+	cmd := exec.Command(utils.GetBinaryPath("debugfs"), "-w", "-f", scr.Name(), image)
 	cmd.Env = []string{"DEBUGFS_PAGER='cat'"}
 	errbuf := bytes.NewBuffer(nil)
 	stdout = bytes.NewBuffer(nil)

--- a/cli/mender-artifact/partition.go
+++ b/cli/mender-artifact/partition.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/utils"
 	"github.com/pkg/errors"
 )
 
@@ -92,7 +93,7 @@ func parseImgPath(imgpath string) (imgname, fpath string, err error) {
 // imgFilesystemtype returns the filesystem type of a partition.
 // Currently only distinguishes ext from fat.
 func imgFilesystemType(imgpath string) (int, error) {
-	cmd := exec.Command("blkid", "-s", "TYPE", imgpath)
+	cmd := exec.Command(utils.GetBinaryPath("blkid"), "-s", "TYPE", imgpath)
 	buf := bytes.NewBuffer(nil)
 	cmd.Stdout = buf
 	if err := cmd.Run(); err != nil {

--- a/utils/binpath.go
+++ b/utils/binpath.go
@@ -1,0 +1,40 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+
+package utils
+
+import (
+	"os/exec"
+	"path"
+)
+
+func GetBinaryPath(command string) string {
+	// first check if command exists in PATH
+	p, err := exec.LookPath(command)
+	if err == nil {
+		return p
+	}
+
+	// maybe sbin isn't included in PATH, check there explicitly.
+	for _, p := range []string{"/usr/sbin", "/sbin", "/usr/local/sbin"} {
+		p, err = exec.LookPath(path.Join(p, command))
+		if err == nil {
+			return p
+		}
+	}
+
+	// not found, but oh well...
+	return command
+}

--- a/utils/binpath_test.go
+++ b/utils/binpath_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func verifyContains(t *testing.T, a string, b string) {
+	if !strings.Contains(a, b) {
+		t.Errorf("GetBinaryPath did not contain '%s' in result '%s'.",
+			b, a)
+	}
+}
+
+
+func TestGetBinaryPath(t *testing.T) {
+	nonexist := "non-existant-command-should-still-be-returned"
+	p := GetBinaryPath(nonexist)
+	verifyContains(t, p, nonexist)
+
+	// Note: assume /bin/true is available on every build-system always.
+
+	alwaysFoundCommand := "true"
+	p = GetBinaryPath(alwaysFoundCommand)
+	verifyContains(t, p, alwaysFoundCommand)
+
+	alwaysFoundCommandFullPath := "/bin/true"
+	p = GetBinaryPath(alwaysFoundCommandFullPath)
+	verifyContains(t, p, alwaysFoundCommandFullPath)
+}


### PR DESCRIPTION
Certain commands are spawned from the mender-artifact command and those
commands may sometimes live outside of $PATH (since /sbin, /usr/sbin,
.. is normally not in a regular users path). First search PATH but
also try other locations.

Adresses: https://tracker.mender.io/browse/MEN-2180
Changelog: fixes issue when binary dependencies are not in PATH
Signed-off-by: Andreas Henriksson <andreas@fatal.se>