### PR TITLE
checking if fsck is on path and returning error if not.

### DIFF
--- a/cli/mender-artifact/debugfs.go
+++ b/cli/mender-artifact/debugfs.go
@@ -41,7 +41,11 @@ import (
 //              32     Checking canceled by user request
 //              128    Shared-library error
 func debugfsRunFsck(image string) error {
-	cmd := exec.Command("fsck.ext4", "-a", image)
+	path, err := exec.LookPath("fsck.ext4")
+	if err != nil {
+		return errors.Wrap(err, "fsck.ext4 command not found")
+	}
+	cmd := exec.Command(path, "-a", image)
 	if err := cmd.Run(); err != nil {
 		// try to get the exit code
 		if exitError, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
@kacf please take a look. tested:

`#./mender-artifact modify /tmp/qemux86-64-uefi-grub_release_1_master.mender --server-uri "$MENDER_SERVER_URL" --tenant-token "$MENDER_TENANT_TOKEN"
Error modifying artifact[/var/folders/c_/j5f_xrnj3790c0pbm3bg_rwm0000gn/T/core-image-full-cmdline-qemux86-64.ext4]: fsck.ext4 command not found.
`