### PR TITLE
MEN-2180: Document mender-artifact dependency upon `debugfs` 

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -258,7 +258,11 @@ func repackArtifact(comp artifact.Compressor, artifact, rootfs, key, newName str
 }
 
 func processSdimg(image string) ([]partition, error) {
-	out, err := exec.Command(utils.GetBinaryPath("parted"), image, "unit s", "print").Output()
+	bin, err := utils.GetBinaryPath("parted")
+	if err != nil {
+		return nil, fmt.Errorf("`parted` binary not found on the system")
+	}
+	out, err := exec.Command(bin, image, "unit s", "print").Output()
 	if err != nil {
 		return nil, errors.Wrap(err, "can not execute `parted` command or image is broken; "+
 			"make sure parted is available in your system and is in the $PATH")

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -247,13 +247,17 @@ func TestCopy(t *testing.T) {
 				switch pf.(type) {
 				case *artifactExtFile:
 					imgpath := pf.(*artifactExtFile).path
-					cmd := exec.Command(utils.GetBinaryPath("debugfs"), "-R", "stat /etc/mender/testkey.key", imgpath)
+					bin, err := utils.GetBinaryPath("debugfs")
+					require.Nil(t, err)
+					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
 					out, err := cmd.CombinedOutput()
 					require.Nil(t, err)
 					require.True(t, strings.Contains(string(out), "Mode:  0600"))
 				case sdimgFile:
 					imgpath := pf.(sdimgFile)[0].(*extFile).path
-					cmd := exec.Command(utils.GetBinaryPath("debugfs"), "-R", "stat /etc/mender/testkey.key", imgpath)
+					bin, err := utils.GetBinaryPath("debugfs")
+					require.Nil(t, err)
+					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
 					out, err := cmd.CombinedOutput()
 					require.Nil(t, err)
 					require.True(t, strings.Contains(string(out), "Mode:  0600"))

--- a/cli/mender-artifact/debugfs_test.go
+++ b/cli/mender-artifact/debugfs_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mendersoftware/mender-artifact/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,4 +48,26 @@ func TestExecuteCommand(t *testing.T) {
 		fmt.Fprintf(os.Stderr, "err: %s\n", err)
 		assert.Contains(t, err.Error(), test.expected, "Unexpected error")
 	}
+}
+
+func TestExternalBinaryDependency(t *testing.T) {
+	// Set the PATH variable to be empty for the test.
+	origPATH := os.Getenv("PATH")
+	// "/usr/sbin", "/sbin", "/usr/local/sbin" also needs to be unset
+	utils.ExternalBinaryPaths = []string{}
+	defer func() {
+		os.Setenv("PATH", origPATH)
+	}()
+	os.Setenv("PATH", "")
+	_, err := debugfsCopyFile("foo", "bar")
+	assert.EqualError(t, err, debugfsMissingErr)
+
+	_, err = executeCommand("foobar", "bash")
+	assert.EqualError(t, err, debugfsMissingErr)
+
+	_, err = processSdimg("foobar")
+	assert.EqualError(t, err, "`parted` binary not found on the system")
+
+	_, err = imgFilesystemType("foobar")
+	assert.EqualError(t, err, "`blkid` binary not found on the system")
 }

--- a/cli/mender-artifact/partition.go
+++ b/cli/mender-artifact/partition.go
@@ -93,7 +93,11 @@ func parseImgPath(imgpath string) (imgname, fpath string, err error) {
 // imgFilesystemtype returns the filesystem type of a partition.
 // Currently only distinguishes ext from fat.
 func imgFilesystemType(imgpath string) (int, error) {
-	cmd := exec.Command(utils.GetBinaryPath("blkid"), "-s", "TYPE", imgpath)
+	bin, err := utils.GetBinaryPath("blkid")
+	if err != nil {
+		return unsupported, fmt.Errorf("`blkid` binary not found on the system")
+	}
+	cmd := exec.Command(bin, "-s", "TYPE", imgpath)
 	buf := bytes.NewBuffer(nil)
 	cmd.Stdout = buf
 	if err := cmd.Run(); err != nil {

--- a/utils/binpath.go
+++ b/utils/binpath.go
@@ -20,21 +20,25 @@ import (
 	"path"
 )
 
-func GetBinaryPath(command string) string {
+var (
+	ExternalBinaryPaths = []string{"/usr/sbin", "/sbin", "/usr/local/sbin"}
+)
+
+func GetBinaryPath(command string) (string, error) {
 	// first check if command exists in PATH
 	p, err := exec.LookPath(command)
 	if err == nil {
-		return p
+		return p, nil
 	}
 
 	// maybe sbin isn't included in PATH, check there explicitly.
-	for _, p := range []string{"/usr/sbin", "/sbin", "/usr/local/sbin"} {
+	for _, p = range ExternalBinaryPaths {
 		p, err = exec.LookPath(path.Join(p, command))
 		if err == nil {
-			return p
+			return p, nil
 		}
 	}
 
 	// not found, but oh well...
-	return command
+	return command, err
 }

--- a/utils/binpath_test.go
+++ b/utils/binpath_test.go
@@ -17,6 +17,8 @@ package utils
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func verifyContains(t *testing.T, a string, b string) {
@@ -29,16 +31,19 @@ func verifyContains(t *testing.T, a string, b string) {
 
 func TestGetBinaryPath(t *testing.T) {
 	nonexist := "non-existant-command-should-still-be-returned"
-	p := GetBinaryPath(nonexist)
+	p, err := GetBinaryPath(nonexist)
+	assert.NotNil(t, err)
 	verifyContains(t, p, nonexist)
 
 	// Note: assume /bin/true is available on every build-system always.
 
 	alwaysFoundCommand := "true"
-	p = GetBinaryPath(alwaysFoundCommand)
+	p, err = GetBinaryPath(alwaysFoundCommand)
+	assert.Nil(t, err)
 	verifyContains(t, p, alwaysFoundCommand)
 
 	alwaysFoundCommandFullPath := "/bin/true"
-	p = GetBinaryPath(alwaysFoundCommandFullPath)
+	p, err = GetBinaryPath(alwaysFoundCommandFullPath)
+	assert.Nil(t, err)
 	verifyContains(t, p, alwaysFoundCommandFullPath)
 }


### PR DESCRIPTION
Changelog: The mender-artifact tool now checks whether the required
external binaries can be found on the system, and if not, returns an appropriate
error message.

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>