### PR TITLE
Add docker container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Docker build uses published asset, no code needed
+*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM buildpack-deps:stretch-curl as tini
+
+ENV TINI_VERSION v0.18.0
+
+RUN mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini && \
+    wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc && \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+    gpg --verify tini.asc && \
+    cp tini /sbin/ && \
+    chmod +x /sbin/tini && \
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    rm -rf /root/.gnupg
+
+FROM debian:latest
+
+COPY --from=tini /sbin/tini /sbin/
+
+ENV MENDER_ARTIFACT_VERSION 2.4.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && cd /usr/bin \
+    && wget https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/${MENDER_ARTIFACT_VERSION}/mender-artifact \
+    && chmod +x mender-artifact
+
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/usr/bin/mender-artifact"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ import (
 
 For sample usage, please see the [Mender client source code](https://github.com/mendersoftware/mender).
 
+## Using the docker image
+
+You can run `mender-artifact` with bind mounting using the following command:
+
+```sh
+docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) mender-artifact <args>
+```
+
 ## Contributing
 
 We welcome and ask for your contribution. If you would like to contribute to Mender, please read our guide on how to best get started [contributing code or


### PR DESCRIPTION
This adds a Dockerfile for running `mender-artifact` anywhere that docker runs.  I've tested it successfully on macOS.