### PR TITLE
Added multi stage dockerfile to contain builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.11 as builder
-RUN apt-get update && apt-get install --no-install-recommends -y musl-dev libc6 git liblzma-dev
+FROM golang:1.11-alpine3.8 as builder
+RUN apk update &&  apk add gcc musl-dev libc6-compat git make xz-dev
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .
 RUN make build
 
-FROM busybox
+FROM alpine:3.8
+RUN apk add xz-dev
 COPY --from=builder /go/src/github.com/mendersoftware/mender-artifact/mender-artifact /go/bin/mender-artifact
 ENTRYPOINT [ "/go/bin/mender-artifact" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.11 as builder
+RUN apt-get update && apt-get install --no-install-recommends -y musl-dev libc6 git liblzma-dev
+RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
+WORKDIR /go/src/github.com/mendersoftware/mender-artifact
+ADD ./ .
+RUN make build
+
+FROM busybox
+COPY --from=builder /go/src/github.com/mendersoftware/mender-artifact/mender-artifact /go/bin/mender-artifact
+ENTRYPOINT [ "/go/bin/mender-artifact" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.11-alpine3.8 as builder
+FROM golang:1.11-alpine3.9 as builder
 RUN apk update &&  apk add gcc musl-dev libc6-compat git make xz-dev
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .
 RUN make build
 
-FROM alpine:3.8
+FROM alpine:3.9
 RUN apk add xz-dev
 COPY --from=builder /go/src/github.com/mendersoftware/mender-artifact/mender-artifact /go/bin/mender-artifact
 ENTRYPOINT [ "/go/bin/mender-artifact" ]

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ endif
 build:
 	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) -o $(PKGNAME) $(BUILDFILES)
 
+build-contained:
+	rm -f mender-artifact; \
+	image_id=$$(docker build -f Dockerfile . | awk '/Successfully built/{print $$NF;}'); \
+	docker run --rm --entrypoint "/bin/sh" -v $(shell pwd):/binary $$image_id -c "cp /go/bin/mender-artifact /binary"; \
+	docker image rm $$image_id;
+
 install:
 	cd $(INSTALL_DIR) && $(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TOOLS = \
 VERSION = $(shell git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
 
 GO_LDFLAGS = \
-	-ldflags "-X main.Version=$(VERSION)"
+	-ldflags "-extldflags '-static' -X main.Version=$(VERSION)"
 
 ifeq ($(V),1)
 BUILDV = -v

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TOOLS = \
 VERSION = $(shell git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
 
 GO_LDFLAGS = \
-	-ldflags "-extldflags '-static' -X main.Version=$(VERSION)"
+	-ldflags "-X main.Version=$(VERSION)"
 
 ifeq ($(V),1)
 BUILDV = -v


### PR DESCRIPTION
While moving other parts of mender to contained docker builds, mender-artifact would also be a nice to have. Due to the lzma dependency this is not based on scratch or busybox, but alpine.

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>