### PR TITLE
MEN-2488: Fix name modify command for rootfs-image Artifacts

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -257,9 +257,24 @@ func repack(comp artifact.Compressor, artifactName string, from io.Reader, to io
 	}
 
 	name := ar.GetArtifactName()
+	provides := ar.GetArtifactProvides()
 	if newName != "" {
 		name = newName
+		if provides != nil {
+			provides.ArtifactName = newName
+		}
 	}
+
+	typeInfoV3 := artifact.TypeInfoV3{
+		Type: "rootfs-image",
+		// Keeping these empty for now. We will likely introduce these
+		// later, when we add support for augmented artifacts.
+		// ArtifactDepends:  &artifact.TypeInfoDepends{"rootfs_image_checksum": c.String("depends-rootfs-image-checksum")},
+		// ArtifactProvides: &artifact.TypeInfoProvides{"rootfs_image_checksum": c.String("provides-rootfs-image-checksum")},
+		ArtifactDepends:  &artifact.TypeInfoDepends{},
+		ArtifactProvides: &artifact.TypeInfoProvides{},
+	}
+
 	err = aWriter.WriteArtifact(
 		&awriter.WriteArtifactArgs{
 			Format:   info.Format,
@@ -268,8 +283,9 @@ func repack(comp artifact.Compressor, artifactName string, from io.Reader, to io
 			Name:     name,
 			Updates:  upd,
 			Scripts:  scr,
-			Provides: ar.GetArtifactProvides(),
+			Provides: provides,
 			Depends:  ar.GetArtifactDepends(),
+			TypeInfoV3: &typeInfoV3,
 		})
 	return ar, err
 }

--- a/cli/mender-artifact/artifacts_test.go
+++ b/cli/mender-artifact/artifacts_test.go
@@ -139,18 +139,45 @@ func WriteArtifact(dir string, ver int, update string) error {
 	aw := awriter.NewWriter(f, comp)
 	switch ver {
 	case 1:
-		// we are alrady having v1 handlers; do nothing
+		// we are already having v1 handlers; do nothing
 	case 2:
 		u = handlers.NewRootfsV2(update)
+	case 3:
+		u = handlers.NewRootfsV3(update)
 	}
 
 	updates := &awriter.Updates{Updates: []handlers.Composer{u}}
+
+	depends := artifact.ArtifactDepends{
+		ArtifactName:      []string{""},
+		CompatibleDevices: []string{""},
+		ArtifactGroup:     []string{""},
+	}
+
+	provides := artifact.ArtifactProvides{
+		ArtifactName:  "test-artifact",
+		ArtifactGroup: "",
+	}
+
+	typeInfoV3 := artifact.TypeInfoV3{
+		Type: "rootfs-image",
+		// Keeping these empty for now. We will likely introduce these
+		// later, when we add support for augmented artifacts.
+		// ArtifactDepends:  &artifact.TypeInfoDepends{"rootfs_image_checksum": c.String("depends-rootfs-image-checksum")},
+		// ArtifactProvides: &artifact.TypeInfoProvides{"rootfs_image_checksum": c.String("provides-rootfs-image-checksum")},
+		ArtifactDepends:  &artifact.TypeInfoDepends{},
+		ArtifactProvides: &artifact.TypeInfoProvides{},
+	}
+
 	return aw.WriteArtifact(&awriter.WriteArtifactArgs{
 		Format:  "mender",
 		Name:    "test-artifact",
 		Version: ver,
 		Devices: []string{"vexpress"},
 		Updates: updates,
+		Provides: &provides,
+		Depends: &depends,
+		TypeInfoV3: &typeInfoV3,
 	})
 }
 

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func copyFile(src, dst string) error {
@@ -181,41 +182,42 @@ func TestModifySdimage(t *testing.T) {
 
 func TestModifyArtifact(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "mender-modify")
-	assert.NoError(t, err)
-
+	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 
 	err = copyFile("mender_test.img", filepath.Join(tmp, "mender_test.img"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	err = WriteArtifact(tmp, 2, filepath.Join(tmp, "mender_test.img"))
-	assert.NoError(t, err)
+	for _, ver := range []int{2, 3} {
+		err = WriteArtifact(tmp, ver, filepath.Join(tmp, "mender_test.img"))
+		assert.NoError(t, err)
 
-	os.Args = []string{"mender-artifact", "modify",
-		"-n", "release-1",
-		filepath.Join(tmp, "artifact.mender")}
+		os.Args = []string{"mender-artifact", "modify",
+			"-n", "release-1",
+			filepath.Join(tmp, "artifact.mender")}
 
-	err = run()
-	assert.NoError(t, err)
-
-	os.Args = []string{"mender-artifact", "read",
-		filepath.Join(tmp, "artifact.mender")}
-
-	r, w, err := os.Pipe()
-	out := os.Stdout
-	defer func() {
-		os.Stdout = out
-	}()
-	os.Stdout = w
-
-	go func() {
 		err = run()
 		assert.NoError(t, err)
-		w.Close()
-	}()
 
-	data, _ := ioutil.ReadAll(r)
-	assert.Contains(t, string(data), "Name: release-1")
+		os.Args = []string{"mender-artifact", "read",
+			filepath.Join(tmp, "artifact.mender")}
+
+		r, w, err := os.Pipe()
+		out := os.Stdout
+		defer func() {
+			os.Stdout = out
+		}()
+		os.Stdout = w
+
+		go func() {
+			err = run()
+			assert.NoError(t, err)
+			w.Close()
+		}()
+
+		data, _ := ioutil.ReadAll(r)
+		assert.Contains(t, string(data), "Name: release-1")
+	}
 }
 
 func TestModifyServerCert(t *testing.T) {


### PR DESCRIPTION
It was not working for Artifact V3 headers. Extended the unit tests to
cover both supported versions.

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>