### PR TITLE
MEN-2486: Unsupport signed modify

### DIFF
--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -30,7 +30,6 @@ import (
 	"github.com/mendersoftware/mender-artifact/utils"
 
 	"github.com/pkg/errors"
-	"github.com/urfave/cli"
 )
 
 type writeUpdateStorer struct {
@@ -290,7 +289,7 @@ func repack(comp artifact.Compressor, artifactName string, from io.Reader, to io
 	return ar, err
 }
 
-func repackArtifact(comp artifact.Compressor, artifact, rootfs, key, newName string) error {
+func repackArtifact(comp artifact.Compressor, artifact, rootfs, newName string) error {
 	art, err := os.Open(artifact)
 	if err != nil {
 		return err
@@ -304,16 +303,7 @@ func repackArtifact(comp artifact.Compressor, artifact, rootfs, key, newName str
 	defer os.Remove(tmp.Name())
 	defer tmp.Close()
 
-	var privateKey []byte
-	if key != "" {
-		privateKey, err = getKey(key)
-		if err != nil {
-
-			return cli.NewExitError(fmt.Sprintf("Can not use signing key provided: %s", err.Error()), 1)
-		}
-	}
-
-	if _, err = repack(comp, artifact, art, tmp, privateKey, newName, rootfs); err != nil {
+	if _, err = repack(comp, artifact, art, tmp, nil, newName, rootfs); err != nil {
 		return err
 	}
 
@@ -383,7 +373,7 @@ func repackSdimg(partitions []partition, image string) error {
 	return nil
 }
 
-func getCandidatesForModify(path string, key []byte) ([]partition, bool, error) {
+func getCandidatesForModify(path string) ([]partition, bool, error) {
 	isArtifact := false
 	modifyCandidates := make([]partition, 0)
 
@@ -394,7 +384,7 @@ func getCandidatesForModify(path string, key []byte) ([]partition, bool, error) 
 	}
 	defer art.Close()
 
-	if err = validate(art, key); err == nil {
+	if err = validate(art, nil); err == nil {
 		// we have VALID artifact, so we need to unpack it and store header
 		isArtifact = true
 		rawImage, err := unpackArtifact(path)
@@ -402,8 +392,6 @@ func getCandidatesForModify(path string, key []byte) ([]partition, bool, error) 
 			return nil, isArtifact, errors.Wrap(err, "can not process artifact")
 		}
 		modifyCandidates = append(modifyCandidates, partition{path: rawImage})
-	} else if err == ErrInvalidSignature {
-		return nil, isArtifact, err
 	} else {
 		parts, err := processSdimg(path)
 		if err != nil {

--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -37,7 +37,7 @@ func Cat(c *cli.Context) (err error) {
 	if !isimg.MatchString(c.Args().First()) {
 		return cli.NewExitError("The input image does not seem to be a valid image", 1)
 	}
-	r, err := virtualPartitionFile.Open(comp, c.Args().First(), c.String("key"))
+	r, err := virtualPartitionFile.Open(comp, c.Args().First())
 	defer func() {
 		if r != nil {
 			r.Close()
@@ -78,7 +78,7 @@ func Copy(c *cli.Context) (err error) {
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
 		}
-		vfile, err = virtualPartitionFile.Open(comp, c.Args().Get(1), c.String("key"))
+		vfile, err = virtualPartitionFile.Open(comp, c.Args().Get(1))
 		defer wclose(vfile)
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
@@ -86,14 +86,14 @@ func Copy(c *cli.Context) (err error) {
 		w = vfile
 	case copyinstdin:
 		r = os.Stdin
-		vfile, err = virtualPartitionFile.Open(comp, c.Args().First(), c.String("key"))
+		vfile, err = virtualPartitionFile.Open(comp, c.Args().First())
 		defer wclose(vfile)
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
 		}
 		w = vfile
 	case copyout:
-		vfile, err = virtualPartitionFile.Open(comp, c.Args().First(), c.String("key"))
+		vfile, err = virtualPartitionFile.Open(comp, c.Args().First())
 		defer wclose(vfile)
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
@@ -148,7 +148,7 @@ func Install(c *cli.Context) (err error) {
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
 		}
-		f, err := virtualPartitionFile.Open(comp, c.Args().Get(1), c.String("key"))
+		f, err := virtualPartitionFile.Open(comp, c.Args().Get(1))
 		defer wclose(f)
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
@@ -184,7 +184,7 @@ func Remove(c *cli.Context) (err error) {
 	if !isimg.MatchString(c.Args().First()) {
 		return cli.NewExitError("The input image does not have a valid extension", 1)
 	}
-	f, err := virtualPartitionFile.Open(comp, c.Args().First(), c.String("key"))
+	f, err := virtualPartitionFile.Open(comp, c.Args().First())
 	defer wclose(f)
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("failed to open the partition reader: err: %v", err), 1)

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -240,7 +240,7 @@ func TestCopy(t *testing.T) {
 				// Cleanup the testkey
 				assert.Nil(t, os.Remove("testkey"))
 				// Check that the permission bits have been set correctly!
-				pf, err := virtualPartitionFile.Open(comp, imgpath+":/etc/mender/testkey.key", "")
+				pf, err := virtualPartitionFile.Open(comp, imgpath+":/etc/mender/testkey.key")
 				defer pf.Close()
 				require.Nil(t, err)
 				// Type switch on the artifact, or sdimg underlying

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -56,6 +56,18 @@ func getCliContext() *cli.App {
 	app.Author = "mender.io"
 	app.Email = "contact@mender.io"
 
+	privateKeyFlag := cli.StringFlag{
+		Name: "key, k",
+		Usage: "Full path to the private key that will be used to verify " +
+			"the artifact signature.",
+	}
+
+	publicKeyFlag := cli.StringFlag{
+		Name: "key, k",
+		Usage: "Full path to the public key that will be used to verify " +
+			"the artifact signature.",
+	}
+
 	//
 	// write
 	//
@@ -89,10 +101,7 @@ func getCliContext() *cli.App {
 			Usage: "Version of the artifact.",
 			Value: LatestFormatVersion,
 		},
-		cli.StringFlag{
-			Name:  "key, k",
-			Usage: "Full path to the private key that will be used to sign the artifact.",
-		},
+		privateKeyFlag,
 		cli.StringSliceFlag{
 			Name: "script, s",
 			Usage: "Full path to the state script(s). You can specify multiple " +
@@ -230,12 +239,6 @@ func getCliContext() *cli.App {
 		},
 	}
 
-	key := cli.StringFlag{
-		Name: "key, k",
-		Usage: "Full path to the public key that will be used to verify " +
-			"the artifact signature.",
-	}
-
 	//
 	// validate
 	//
@@ -245,9 +248,7 @@ func getCliContext() *cli.App {
 		Action:      validateArtifact,
 		UsageText:   "mender-artifact validate [options] <pathspec>",
 		Description: "This command validates artifact file provided by pathspec.",
-	}
-	validate.Flags = []cli.Flag{
-		key,
+		Flags:       []cli.Flag{publicKeyFlag},
 	}
 
 	//
@@ -259,7 +260,7 @@ func getCliContext() *cli.App {
 		ArgsUsage:   "<artifact path>",
 		Action:      readArtifact,
 		Description: "This command validates artifact file provided by pathspec.",
-		Flags:       []cli.Flag{key},
+		Flags:       []cli.Flag{publicKeyFlag},
 	}
 
 	//
@@ -274,7 +275,7 @@ func getCliContext() *cli.App {
 		Description: "This command signs artifact file provided by pathspec.",
 	}
 	sign.Flags = []cli.Flag{
-		key,
+		privateKeyFlag,
 		cli.StringFlag{
 			Name: "output-path, o",
 			Usage: "Full path to output signed artifact file; " +

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -299,10 +299,6 @@ func getCliContext() *cli.App {
 
 	modify.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "key, k",
-			Usage: "Full path to the private key that will be used to sign the artifact after modifying.",
-		},
-		cli.StringFlag{
 			Name:  "server-uri, u",
 			Usage: "Mender server URI; the default URI will be replaced with given one.",
 		},

--- a/cli/mender-artifact/modify.go
+++ b/cli/mender-artifact/modify.go
@@ -42,7 +42,7 @@ func modifyArtifact(c *cli.Context) error {
 	}
 
 	modifyCandidates, isArtifact, err :=
-		getCandidatesForModify(c.Args().First(), nil)
+		getCandidatesForModify(c.Args().First())
 
 	if err != nil {
 		return cli.NewExitError("Error selecting images for modification: "+err.Error(), 1)
@@ -75,7 +75,7 @@ func modifyArtifact(c *cli.Context) error {
 	if isArtifact {
 		// re-create the artifact
 		err := repackArtifact(comp, c.Args().First(), modifyCandidates[0].path,
-			"", c.String("name"))
+			c.String("name"))
 		if err != nil {
 			return cli.NewExitError("Can not recreate artifact: "+err.Error(), 1)
 		}

--- a/cli/mender-artifact/modify.go
+++ b/cli/mender-artifact/modify.go
@@ -15,9 +15,7 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -43,13 +41,8 @@ func modifyArtifact(c *cli.Context) error {
 		return cli.NewExitError("File ["+c.Args().First()+"] does not exist.", 1)
 	}
 
-	pubKey, err := processModifyKey(c.String("key"))
-	if err != nil {
-		return cli.NewExitError("Error processing private key: "+err.Error(), 1)
-	}
-
 	modifyCandidates, isArtifact, err :=
-		getCandidatesForModify(c.Args().First(), pubKey)
+		getCandidatesForModify(c.Args().First(), nil)
 
 	if err != nil {
 		return cli.NewExitError("Error selecting images for modification: "+err.Error(), 1)
@@ -82,7 +75,7 @@ func modifyArtifact(c *cli.Context) error {
 	if isArtifact {
 		// re-create the artifact
 		err := repackArtifact(comp, c.Args().First(), modifyCandidates[0].path,
-			c.String("key"), c.String("name"))
+			"", c.String("name"))
 		if err != nil {
 			return cli.NewExitError("Can not recreate artifact: "+err.Error(), 1)
 		}
@@ -197,29 +190,4 @@ func modifyExisting(c *cli.Context, image string) error {
 	}
 
 	return nil
-}
-
-func processModifyKey(keyPath string) ([]byte, error) {
-	// extract public key from it private counterpart
-	if keyPath != "" {
-		priv, err := getKey(keyPath)
-		if err != nil {
-			return nil, errors.Wrap(err, "can not get private key")
-		}
-		pubKeyRaw, err := artifact.GetPublic(priv)
-		if err != nil {
-			return nil, errors.Wrap(err, "can not get private key public counterpart")
-		}
-
-		buf := &bytes.Buffer{}
-		err = pem.Encode(buf, &pem.Block{
-			Type:  "PUBLIC KEY",
-			Bytes: pubKeyRaw,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "can not encode public key")
-		}
-		return buf.Bytes(), nil
-	}
-	return nil, nil
 }

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -99,7 +99,7 @@ func verify(image, file, expected string) bool {
 func verifySDImg(image, file, expected string) bool {
 
 	modifyCandidates, isArtifact, err :=
-		getCandidatesForModify(image, nil)
+		getCandidatesForModify(image)
 
 	if err != nil {
 		return false

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -287,45 +287,44 @@ func TestModifySigned(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(tmp, "ecdsa.key"), []byte(PrivateECDSAKey), 0711)
 	assert.NoError(t, err)
 
-	// Create and sign artifact using RSA private key.
-	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
-		"-n", "release-1", "-f", filepath.Join(tmp, "mender_test.img"),
-		"-o", filepath.Join(tmp, "artifact.mender"),
-		"-k", filepath.Join(tmp, "rsa.key")}
-	err = run()
-	assert.NoError(t, err)
+	for _, key := range []string{"rsa.key", "ecdsa.key"} {
 
-	// Modify the artifact and re-sign it using the same RSA private key.
-	os.Args = []string{"mender-artifact", "modify",
-		"-n", "release-2",
-		"-k", filepath.Join(tmp, "rsa.key"),
+		// Create and sign artifact using RSA private key.
+		os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
+			"-n", "release-1", "-f", filepath.Join(tmp, "mender_test.img"),
+			"-o", filepath.Join(tmp, "artifact.mender"),
+			"-k", filepath.Join(tmp, key)}
+		err = run()
+		assert.NoError(t, err)
+
+		// Modify the artifact, the result shall be unsigned
+		os.Args = []string{"mender-artifact", "modify",
+			"-n", "release-2",
+			filepath.Join(tmp, "artifact.mender")}
+
+		err = run()
+		assert.NoError(t, err)
+
+		// Check for field update and unsigned state
+		os.Args = []string{"mender-artifact", "read",
 		filepath.Join(tmp, "artifact.mender")}
 
-	err = run()
-	assert.NoError(t, err)
+		r, w, err := os.Pipe()
+		out := os.Stdout
+		defer func() {
+			os.Stdout = out
+		}()
+		os.Stdout = w
 
-	// Modify the artifact again, this time leaving it unsigned (no private key provided).
-	os.Args = []string{"mender-artifact", "modify",
-		"-n", "release-3",
-		filepath.Join(tmp, "artifact.mender")}
+		go func() {
+			err = run()
+			assert.NoError(t, err)
+			w.Close()
+		}()
 
-	err = run()
-	assert.NoError(t, err)
+		data, _ := ioutil.ReadAll(r)
+		assert.Contains(t, string(data), "Name: release-2")
+		assert.Contains(t, string(data), "Signature: no signature")
 
-	// Create artifact again, this time with EC private key.
-	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
-		"-n", "release-1", "-f", filepath.Join(tmp, "mender_test.img"),
-		"-o", filepath.Join(tmp, "artifact_ecdsa.mender"),
-		"-k", filepath.Join(tmp, "ecdsa.key")}
-	err = run()
-	assert.NoError(t, err)
-
-	// Modify artifact, re-signing with same EC private key.
-	os.Args = []string{"mender-artifact", "modify",
-		"-n", "release-2",
-		"-k", filepath.Join(tmp, "ecdsa.key"),
-		filepath.Join(tmp, "artifact_ecdsa.mender")}
-
-	err = run()
-	assert.NoError(t, err)
+	}
 }

--- a/cli/mender-artifact/sign.go
+++ b/cli/mender-artifact/sign.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -47,21 +47,22 @@ func signExisting(c *cli.Context) error {
 
 	tFile, err := ioutil.TempFile(filepath.Dir(c.Args().First()), "mender-artifact")
 	if err != nil {
-		return errors.Wrap(err,
-			"Can not create temporary file for storing artifact")
+		err = errors.Wrap(err, "Can not create temporary file for storing artifact")
+		cli.NewExitError(err, 1)
 	}
 	defer os.Remove(tFile.Name())
 	defer tFile.Close()
 
 	f, err := os.Open(c.Args().First())
 	if err != nil {
-		return errors.Wrapf(err, "Can not open: %s", c.Args().First())
+		err = errors.Wrapf(err, "Can not open: %s", c.Args().First())
+		return cli.NewExitError(err, 1)
 	}
 	defer f.Close()
 
 	reader, err := repack(comp, c.Args().First(), f, tFile, privateKey, "", "")
 	if err != nil {
-		return err
+		return cli.NewExitError(err, 1)
 	}
 
 	switch ver := reader.GetInfo().Version; ver {


### PR DESCRIPTION
MEN-2486: Remove support for re-signing modified artifacts

It was not properly implemented; the "-k" parameter was being used as
the public key to verify the signature of the current Artifact and as
the private key as well to sign the modifyied Artifact.

In any case, it is better to completely remove this option and use the
mender-convert sign after modifications to produce the final Artifact

Removed the functionality and improved the test to actually check
something after the modifications.

Changelog: `mender-artifact modify` does not support anymore signing the
Artifact after the modification. Use `mender-convert sign` after the
modification to sign the Artifact.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>