### PR TITLE
MEN-2580: Add `dump` command to mender-artifact.

### DIFF
--- a/cli/mender-artifact/dump.go
+++ b/cli/mender-artifact/dump.go
@@ -1,0 +1,246 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/mendersoftware/mender-artifact/areader"
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/handlers"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+type dumpFileStore struct {
+	fileDir string
+	args    *[]string
+}
+
+func DumpCommand(c *cli.Context) error {
+	var dumpArgs []string
+
+	if c.NArg() != 1 {
+		return cli.NewExitError("Need to specify exactly one Artifact with dump command",
+			errArtifactInvalidParameters)
+	}
+
+	art, err := os.Open(c.Args().First())
+	if err != nil {
+		return cli.NewExitError(fmt.Sprintf(
+			"Error opening Artifact: %s", err.Error()),
+			errArtifactOpen)
+	}
+	defer art.Close()
+
+	ar := areader.NewReader(art)
+
+	scriptsReadCallback := func(r io.Reader, i os.FileInfo) error {
+		fullPath := path.Join(c.String("scripts"), i.Name())
+		script, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+		if err != nil {
+			return err
+		}
+		defer script.Close()
+
+		_, err = io.Copy(script, r)
+		if err != nil {
+			return err
+		}
+
+		dumpArgs = append(dumpArgs, "--script", fullPath)
+
+		return nil
+	}
+	if len(c.String("scripts")) > 0 {
+		err = os.MkdirAll(c.String("scripts"), 0755)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf(
+				"Could not create directory: %s", err.Error()), errSystemError)
+		}
+		ar.ScriptsReadCallback = scriptsReadCallback
+	}
+
+	err = ar.ReadArtifactHeaders()
+	if err != nil {
+		return cli.NewExitError(fmt.Sprintf("Error dumping Artifact: %s",
+			err.Error()), errArtifactInvalid)
+	}
+
+	err = dumpPayloads(c, ar, &dumpArgs)
+	if err != nil {
+		return err
+	}
+
+	if c.Bool("print-cmdline") {
+		printCmdline(ar, dumpArgs)
+	}
+
+	return nil
+}
+
+func dumpPayloads(c *cli.Context, ar *areader.Reader, dumpArgs *[]string) error {
+	handlers := ar.GetHandlers()
+	if len(handlers) != 1 {
+		return cli.NewExitError("The dump command can handle one payload only",
+			errArtifactUnsupportedFeature)
+	}
+
+	if len(c.String("meta-data")) > 0 {
+		err := dumpMetaData(c.String("meta-data"), dumpArgs, handlers)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(c.String("files")) > 0 {
+		store := &dumpFileStore{
+			fileDir: c.String("files"),
+			args:    dumpArgs,
+		}
+		for _, h := range handlers {
+			h.SetUpdateStorerProducer(store)
+		}
+	}
+
+	err := ar.ReadArtifactData()
+	if err != nil {
+		return cli.NewExitError(fmt.Sprintf("Error dumping Artifact: %s",
+			err.Error()), errArtifactInvalid)
+	}
+
+	return nil
+}
+
+func dumpMetaData(metaDataDir string, dumpArgs *[]string, handlers map[int]handlers.Installer) error {
+	err := os.MkdirAll(metaDataDir, 0755)
+	if err != nil {
+		return cli.NewExitError(fmt.Sprintf(
+			"Unable to create directory: %s", err.Error()), errSystemError)
+	}
+
+	// Hardcode to 0 index for now.
+	handler := handlers[0]
+
+	for _, augmented := range []bool{false, true} {
+		var metaData map[string]interface{}
+		var fullPath string
+		var metaDataArg string
+		if augmented {
+			metaData = handler.GetUpdateAugmentMetaData()
+			fullPath = path.Join(metaDataDir, "0000.meta-data-augment")
+			metaDataArg = "--augment-meta-data"
+		} else {
+			metaData = handler.GetUpdateOriginalMetaData()
+			fullPath = path.Join(metaDataDir, "0000.meta-data")
+			metaDataArg = "--meta-data"
+		}
+
+		if len(metaData) == 0 {
+			continue
+		}
+
+		metaDataFd, err := os.OpenFile(fullPath,
+			os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf(
+				"Unable to create meta-data file: %s", err.Error()), errSystemError)
+		}
+		defer metaDataFd.Close()
+
+		w := json.NewEncoder(metaDataFd)
+		err = w.Encode(metaData)
+		if err != nil {
+			return errors.New("Unencodeable map in dumpPayloads. Should not happen.")
+		}
+
+		*dumpArgs = append(*dumpArgs, metaDataArg, fullPath)
+	}
+
+	return nil
+}
+
+func printCmdline(ar *areader.Reader, args []string) {
+	// Even if it is a rootfs payload, we use the module-image writer, since
+	// this can recreate either type.
+	fmt.Printf("write module-image")
+
+	artProvs := ar.GetArtifactProvides()
+	fmt.Printf(" --artifact-name %s", artProvs.ArtifactName)
+	if len(artProvs.ArtifactGroup) > 0 {
+		fmt.Printf(" --provides-group %s", artProvs.ArtifactGroup)
+	}
+
+	artDeps := ar.GetArtifactDepends()
+	if len(artDeps.ArtifactName) > 0 {
+		fmt.Printf(" --artifact-name-depends %s", strings.Join(artDeps.ArtifactName, " --artifact-name-depends "))
+	}
+	fmt.Printf(" --device-type %s", strings.Join(artDeps.CompatibleDevices, " --device-type "))
+	if len(artDeps.ArtifactGroup) > 0 {
+		fmt.Printf(" --depends-groups %s", strings.Join(artDeps.ArtifactGroup, " --depends-groups "))
+	}
+
+	handlers := ar.GetHandlers()
+	if len(handlers) > 0 {
+		fmt.Printf(" --type %s", ar.GetHandlers()[0].GetUpdateType())
+	}
+
+	if len(args) > 0 {
+		fmt.Printf(" %s\n", strings.Join(args, " "))
+	}
+}
+
+func (d *dumpFileStore) NewUpdateStorer(updateType string, payloadNum int) (handlers.UpdateStorer, error) {
+	return d, nil
+}
+
+func (d *dumpFileStore) Initialize(artifactHeaders,
+	artifactAugmentedHeaders artifact.HeaderInfoer,
+	payloadHeaders handlers.ArtifactUpdateHeaders) error {
+
+	return nil
+}
+
+func (d *dumpFileStore) PrepareStoreUpdate() error {
+	return os.MkdirAll(d.fileDir, 0755)
+}
+
+func (d *dumpFileStore) StoreUpdate(r io.Reader, info os.FileInfo) error {
+	fullPath := path.Join(d.fileDir, info.Name())
+	file, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, r)
+	if err != nil {
+		return err
+	}
+
+	*d.args = append(*d.args, "--file", fullPath)
+
+	return nil
+}
+
+func (d *dumpFileStore) FinishStoreUpdate() error {
+	return nil
+}

--- a/cli/mender-artifact/dump_test.go
+++ b/cli/mender-artifact/dump_test.go
@@ -1,0 +1,220 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeFile(t *testing.T, tmpdir, name, content string) {
+	err := ioutil.WriteFile(path.Join(tmpdir, name), []byte(content), 0644)
+	require.NoError(t, err)
+}
+
+func runAndCollectStdout(args []string) (string, error) {
+	savedStdout := os.Stdout
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = pipeW
+	defer func() {
+		os.Stdout = savedStdout
+		pipeW.Close()
+		pipeR.Close()
+	}()
+
+	var goRoutineErr error
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				goRoutineErr = errors.Errorf("%v", r)
+			}
+			os.Stdout.Close()
+		}()
+
+		goRoutineErr = getCliContext().Run(args)
+	}()
+
+	printed, err := ioutil.ReadAll(pipeR)
+	if err != nil {
+		return "", err
+	}
+
+	if goRoutineErr != nil {
+		return "", goRoutineErr
+	}
+
+	return strings.TrimSpace(string(printed)), nil
+}
+
+func TestDumpContent(t *testing.T) {
+	for _, imageType := range []string{"rootfs-image", "my-own-type"} {
+		t.Run(imageType, func(t *testing.T) {
+			testDumpContent(t, imageType)
+		})
+	}
+}
+
+func testDumpContent(t *testing.T, imageType string) {
+	tmpdir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	makeFile(t, tmpdir, "file", "payload")
+	makeFile(t, tmpdir, "file2", "payload2")
+	makeFile(t, tmpdir, "meta-data", "{\"a\":\"b\"}")
+	makeFile(t, tmpdir, "ArtifactInstall_Enter_45_test", "Bash magic")
+	makeFile(t, tmpdir, "ArtifactCommit_Leave_55", "More Bash magic")
+
+	// --------------------------------------------------------------------
+	// Single values
+	// --------------------------------------------------------------------
+
+	// Use "module-image" writer here, so that we can insert some extra
+	// fields that aren't typically in rootfs-images. One of these is
+	// meta-data, which we don't use at the time of writing this, but which
+	// may be used later.
+	err = getCliContext().Run([]string{"mender-artifact", "write", "module-image",
+		"-o", path.Join(tmpdir, "artifact.mender"),
+		"-n", "Name",
+		"-t", "TestDevice",
+		"-T", imageType,
+		"-N", "dependsOnArtifact",
+		"-f", path.Join(tmpdir, "file"),
+		"-m", path.Join(tmpdir, "meta-data"),
+		"-s", path.Join(tmpdir, "ArtifactInstall_Enter_45_test"),
+		"-d", "testDepends:someDep",
+		"-p", "testProvides:someProv",
+		"-g", "providesGroup",
+		"-G", "dependsGroup"})
+	require.NoError(t, err)
+
+	printed, err := runAndCollectStdout([]string{"mender-artifact", "dump",
+		"--scripts", path.Join(tmpdir, "scripts"),
+		"--meta-data", path.Join(tmpdir, "meta"),
+		"--files", path.Join(tmpdir, "files"),
+		"--print-cmdline",
+		path.Join(tmpdir, "artifact.mender")})
+
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("write module-image"+
+		" --artifact-name Name"+
+		" --provides-group providesGroup"+
+		" --artifact-name-depends dependsOnArtifact"+
+		" --device-type TestDevice"+
+		" --depends-groups dependsGroup"+
+		" --type %s"+
+		" --script %s/scripts/ArtifactInstall_Enter_45_test"+
+		" --meta-data %s/meta/0000.meta-data"+
+		" --file %s/files/file",
+		imageType, tmpdir, tmpdir, tmpdir),
+		string(printed))
+
+	// --------------------------------------------------------------------
+	// Multiple values
+	// --------------------------------------------------------------------
+
+	if imageType == "rootfs-image" {
+		// "rootfs-image" doesn't support multiple payload files, so
+		// skip testing that any further.
+		return
+	}
+
+	os.RemoveAll(path.Join(tmpdir, "scripts"))
+	os.RemoveAll(path.Join(tmpdir, "meta"))
+	os.RemoveAll(path.Join(tmpdir, "files"))
+
+	err = getCliContext().Run([]string{"mender-artifact", "write", "module-image",
+		"-o", path.Join(tmpdir, "artifact.mender"),
+		"-n", "Name",
+		"-t", "TestDevice",
+		"-t", "TestDevice2",
+		"-T", imageType,
+		"-N", "dependsOnArtifact",
+		"-N", "dependsOnArtifact2",
+		"-f", path.Join(tmpdir, "file"),
+		"-f", path.Join(tmpdir, "file2"),
+		"-m", path.Join(tmpdir, "meta-data"),
+		"-s", path.Join(tmpdir, "ArtifactInstall_Enter_45_test"),
+		"-s", path.Join(tmpdir, "ArtifactCommit_Leave_55"),
+		"-d", "testDepends:someDep",
+		"-p", "testProvides:someProv",
+		"-d", "testDepends2:someDep2",
+		"-p", "testProvides2:someProv2",
+		"-g", "providesGroup",
+		"-G", "dependsGroup",
+		"-G", "dependsGroup2"})
+	require.NoError(t, err)
+
+	printed, err = runAndCollectStdout([]string{"mender-artifact", "dump",
+		"--scripts", path.Join(tmpdir, "scripts"),
+		"--meta-data", path.Join(tmpdir, "meta"),
+		"--files", path.Join(tmpdir, "files"),
+		"--print-cmdline",
+		path.Join(tmpdir, "artifact.mender")})
+
+	assert.NoError(t, err)
+	printedStr := string(printed)
+	// The scripts are stored in a map, where the order is unpredictable, so
+	// cover both cases.
+	if strings.Index(printedStr, "ArtifactInstall_Enter_45_test") < strings.Index(printedStr, "ArtifactCommit_Leave_55") {
+		assert.Equal(t, fmt.Sprintf("write module-image"+
+			" --artifact-name Name"+
+			" --provides-group providesGroup"+
+			" --artifact-name-depends dependsOnArtifact"+
+			" --artifact-name-depends dependsOnArtifact2"+
+			" --device-type TestDevice"+
+			" --device-type TestDevice2"+
+			" --depends-groups dependsGroup"+
+			" --depends-groups dependsGroup2"+
+			" --type %s"+
+			" --script %s/scripts/ArtifactInstall_Enter_45_test"+
+			" --script %s/scripts/ArtifactCommit_Leave_55"+
+			" --meta-data %s/meta/0000.meta-data"+
+			" --file %s/files/file"+
+			" --file %s/files/file2",
+			imageType, tmpdir, tmpdir, tmpdir, tmpdir, tmpdir),
+			printedStr)
+	} else {
+		assert.Equal(t, fmt.Sprintf("write module-image"+
+			" --artifact-name Name"+
+			" --provides-group providesGroup"+
+			" --artifact-name-depends dependsOnArtifact"+
+			" --artifact-name-depends dependsOnArtifact2"+
+			" --device-type TestDevice"+
+			" --device-type TestDevice2"+
+			" --depends-groups dependsGroup"+
+			" --depends-groups dependsGroup2"+
+			" --type %s"+
+			" --script %s/scripts/ArtifactCommit_Leave_55"+
+			" --script %s/scripts/ArtifactInstall_Enter_45_test"+
+			" --meta-data %s/meta/0000.meta-data"+
+			" --file %s/files/file"+
+			" --file %s/files/file2",
+			imageType, tmpdir, tmpdir, tmpdir, tmpdir, tmpdir),
+			printedStr)
+	}
+}

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -31,6 +31,8 @@ const (
 	errArtifactCreate
 	errArtifactOpen
 	errArtifactInvalid
+	errArtifactUnsupportedFeature
+	errSystemError
 )
 
 // Version of the mender-artifact CLI tool
@@ -366,6 +368,35 @@ func getCliContext() *cli.App {
 		},
 	}
 
+	//
+	// dump
+	//
+	dumpCommand := cli.Command{
+		Name:        "dump",
+		Usage:       "Dump contents from Artifacts",
+		ArgsUsage:   "<Artifact>",
+		Description: "Dump various raw files from the Artifact. These can be used to create a new Artifact with the same components.",
+		Action:      DumpCommand,
+	}
+	dumpCommand.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "files",
+			Usage: "Dump all included files in the first payload into given folder",
+		},
+		cli.StringFlag{
+			Name:  "meta-data",
+			Usage: "Dump the contents of the meta-data field in the first payload into given folder",
+		},
+		cli.StringFlag{
+			Name:  "scripts",
+			Usage: "Dump all included state scripts into given folder",
+		},
+		cli.BoolFlag{
+			Name:  "print-cmdline",
+			Usage: "Print the command line that can recreate the same Artifact with the components being dumped. If all the components are being dumped, a nearly identical Artifact can be created. Note that timestamps will cause the checksum of the Artifact to be different, and signatures can not be recreated this way. The command line will only use long option names.",
+		},
+	}
+
 	compressors := artifact.GetRegisteredCompressorIds()
 	globalFlags := []cli.Flag{
 		cli.StringFlag{
@@ -386,6 +417,7 @@ func getCliContext() *cli.App {
 		cat,
 		install,
 		remove,
+		dumpCommand,
 	}
 	app.Flags = append([]cli.Flag{}, globalFlags...)
 

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -32,6 +32,7 @@ type Rootfs struct {
 	regularHeaderRead bool
 
 	typeInfoV3 *artifact.TypeInfoV3
+	metaData   map[string]interface{}
 
 	// If this is augmented instance: The original instance.
 	original ArtifactUpdate
@@ -139,7 +140,26 @@ func (rp *Rootfs) ReadHeader(r io.Reader, path string, version int, augmented bo
 		}
 
 	case filepath.Base(path) == "meta-data":
-		// TODO: implement when needed
+		dec := json.NewDecoder(r)
+		var data interface{}
+		err := dec.Decode(&data)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return errors.Wrap(err, "error reading meta-data")
+		}
+		jsonObj, ok := data.(map[string]interface{})
+		if !ok {
+			return errors.New("Top level object in meta-data must be a JSON object")
+		}
+		if augmented {
+			err = rp.setUpdateAugmentMetaData(jsonObj)
+		} else {
+			err = rp.setUpdateOriginalMetaData(jsonObj)
+		}
+		if err != nil {
+			return err
+		}
 	case match(artifact.HeaderDirectory+"/*/signatures/*", path),
 		match(artifact.HeaderDirectory+"/*/scripts/*/*", path):
 		if augmented {
@@ -247,6 +267,23 @@ func (rfs *Rootfs) GetUpdateMetaData() (map[string]interface{}, error) {
 	return rfs.GetUpdateOriginalMetaData(), nil
 }
 
+func (rfs *Rootfs) setUpdateOriginalMetaData(jsonObj map[string]interface{}) error {
+	if rfs.original != nil {
+		return errors.New("setUpdateOriginalMetaData() called on non-original instance.")
+	} else {
+		rfs.metaData = jsonObj
+	}
+	return nil
+}
+
+func (rfs *Rootfs) setUpdateAugmentMetaData(jsonObj map[string]interface{}) error {
+	if rfs.original == nil {
+		return errors.New("Called setUpdateAugmentMetaData() on non-augment instance")
+	}
+	rfs.metaData = jsonObj
+	return nil
+}
+
 func (rfs *Rootfs) GetUpdateOriginalDepends() *artifact.TypeInfoDepends {
 	if rfs.typeInfoV3 == nil {
 		return nil
@@ -262,7 +299,11 @@ func (rfs *Rootfs) GetUpdateOriginalProvides() *artifact.TypeInfoProvides {
 }
 
 func (rfs *Rootfs) GetUpdateOriginalMetaData() map[string]interface{} {
-	return nil
+	if rfs.original != nil {
+		return rfs.original.GetUpdateOriginalMetaData()
+	} else {
+		return rfs.metaData
+	}
 }
 
 func (rfs *Rootfs) GetUpdateAugmentDepends() *artifact.TypeInfoDepends {
@@ -274,7 +315,11 @@ func (rfs *Rootfs) GetUpdateAugmentProvides() *artifact.TypeInfoProvides {
 }
 
 func (rfs *Rootfs) GetUpdateAugmentMetaData() map[string]interface{} {
-	return nil
+	if rfs.original == nil {
+		return nil
+	} else {
+		return rfs.metaData
+	}
 }
 
 func (rfs *Rootfs) ComposeHeader(args *ComposeHeaderArgs) error {


### PR DESCRIPTION
It takes an artifact as input, some optional dumping directories, and
writes the various raw files from the artifact into those directories.
The parameter `--print-cmdline` can be used to generate a command line
which can be used to recreate the same artifact from the dumped files.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>