### PR TITLE
MEN-2745: 'mender-artifact cp' now requires '-' in order to read stdin

### DIFF
--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -93,7 +93,7 @@ func Copy(c *cli.Context) (err error) {
 		return nil
 	case copyinstdin:
 		r = os.Stdin
-		vfile, err = virtualPartitionFile.Open(comp, c.Args().First())
+		vfile, err = virtualPartitionFile.Open(comp, c.Args().Get(1))
 		defer wclose(vfile)
 		if err != nil {
 			return cli.NewExitError(err, 1)
@@ -214,33 +214,28 @@ const (
 
 func parseCLIOptions(c *cli.Context) int {
 
-	finfo, err := os.Stdin.Stat()
-	if err != nil {
-		return criterror
+	if c.NArg() != 2 {
+		return argerror
 	}
 
-	// no data on stdin
-	if finfo.Mode()&os.ModeNamedPipe == 0 {
-		if c.NArg() != 2 {
-			return argerror
-		}
-		switch {
-
-		case isimg.MatchString(c.Args().First()):
-			return copyout
-
-		case isimg.MatchString(c.Args().Get(1)):
-			return copyin
-
-		default:
+	// If the first argument is '-', read from stdin
+	if c.Args().First() == "-" {
+		// Read from stdin
+		if !isimg.MatchString(c.Args().Get(1)) {
 			return parseError
+		}
+		return copyinstdin
+	}
 
-		}
-	} else {
-		// data on stdin
-		if isimg.MatchString(c.Args().First()) {
-			return copyinstdin
-		}
+	switch {
+
+	case isimg.MatchString(c.Args().First()):
+		return copyout
+
+	case isimg.MatchString(c.Args().Get(1)):
+		return copyin
+
+	default:
 		return parseError
 	}
 }

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -668,7 +668,7 @@ func TestCopyFromStdin(t *testing.T) {
 			name: "Test boot partition file copy from stdin (ext4, fat)",
 			setupTestFunc: func(ta testArgs) {
 				ta.stdinPipe.Write([]byte("foobar"))
-				os.Args = []string{"mender-artifact", "cp", ta.testImg + ":/uboot/foo.txt"}
+				os.Args = []string{"mender-artifact", "cp", "-", ta.testImg + ":/uboot/foo.txt"}
 			},
 			verifyTestFunc: func(te testExpects) {
 				assert.Nil(t, te.err)
@@ -676,7 +676,7 @@ func TestCopyFromStdin(t *testing.T) {
 				// Copy back out and verify
 				os.Args = []string{"mender-artifact", "cp", te.testImg + ":/uboot/foo.txt", "output.txt"}
 				err := run()
-				// defer os.Remove("output.txt")
+				defer os.Remove("output.txt")
 				assert.Nil(t, err)
 				of, err := ioutil.ReadFile("output.txt")
 				assert.Nil(t, err)
@@ -687,7 +687,7 @@ func TestCopyFromStdin(t *testing.T) {
 			name: "Test non existing dir from stdin (ext, fat)",
 			setupTestFunc: func(ta testArgs) {
 				ta.stdinPipe.Write([]byte("foobar"))
-				os.Args = []string{"mender-artifact", "cp", ta.testImg + ":/uboot/nonexisting/foo.txt"}
+				os.Args = []string{"mender-artifact", "cp", "-", ta.testImg + ":/uboot/nonexisting/foo.txt"}
 			},
 			verifyTestFunc: func(te testExpects) {
 				assert.Error(t, te.err, te.name, te.testImg)

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -329,8 +329,10 @@ func getCliContext() *cli.App {
 		Name:        "cp",
 		Usage:       "cp <src> <dst>",
 		Description: "Copies a file into or out of a mender artifact, or sdimg",
-		UsageText:   "Copy from or into an artifact, or sdimg where either the <src> or <dst> has to be of the form [artifact|sdimg]:<filepath>",
-		Action:      Copy,
+		UsageText: "Copy from or into an artifact, or sdimg where either the <src>" +
+			" or <dst> has to be of the form [artifact|sdimg]:<filepath>, <src> can" +
+			"come from stdin in the case that <src> is '-'",
+		Action: Copy,
 	}
 
 	cat := cli.Command{


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>