### PR TITLE
Fix: mender-artifact modify did not clean up the temp-files created

### DIFF
--- a/cli/mender-artifact/modify.go
+++ b/cli/mender-artifact/modify.go
@@ -55,6 +55,11 @@ func modifyArtifact(c *cli.Context) error {
 		}
 	} else if candidateType == RawSDImage {
 		if len(modifyCandidates) == 4 { // sdimg
+			defer func(partitions []partition) {
+				for _, part := range partitions {
+					os.Remove(part.path)
+				}
+			}(modifyCandidates)
 			modifyCandidates = modifyCandidates[1:3]
 		}
 	}

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -104,6 +104,12 @@ func verifySDImg(image, file, expected string) bool {
 	candidateType, modifyCandidates, err :=
 		getCandidatesForModify(image)
 
+	defer func(partitions []partition) {
+		for _, part := range partitions {
+			os.Remove(part.path)
+		}
+	}(modifyCandidates)
+
 	if err != nil {
 		return false
 	}
@@ -310,7 +316,7 @@ func TestModifyRootfsSigned(t *testing.T) {
 
 		// Check for field update and unsigned state
 		os.Args = []string{"mender-artifact", "read",
-		filepath.Join(tmp, "artifact.mender")}
+			filepath.Join(tmp, "artifact.mender")}
 
 		r, w, err := os.Pipe()
 		out := os.Stdout
@@ -387,26 +393,26 @@ func TestModifyModuleArtifact(t *testing.T) {
 	}
 	err = run()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(),	"mender-artifact can only modify ext4 payloads")
+	assert.Contains(t, err.Error(), "mender-artifact can only modify ext4 payloads")
 
 	os.Args = []string{
 		"mender-artifact", "modify", "-c", "dummy-cert", artfile,
 	}
 	err = run()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(),	"mender-artifact can only modify ext4 payloads")
+	assert.Contains(t, err.Error(), "mender-artifact can only modify ext4 payloads")
 
 	os.Args = []string{
 		"mender-artifact", "modify", "-v", "dummy-key", artfile,
 	}
 	err = run()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(),	"mender-artifact can only modify ext4 payloads")
+	assert.Contains(t, err.Error(), "mender-artifact can only modify ext4 payloads")
 
 	os.Args = []string{
 		"mender-artifact", "modify", "-t", "dummy-token", artfile,
 	}
 	err = run()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(),	"mender-artifact can only modify ext4 payloads")
+	assert.Contains(t, err.Error(), "mender-artifact can only modify ext4 payloads")
 }


### PR DESCRIPTION
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>