### PR TITLE
Do not close the pipe in TestCopyFromStdin twice

### DIFF
--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -702,7 +702,6 @@ func TestCopyFromStdin(t *testing.T) {
 			// Copy in from stdin
 			r, w, err := os.Pipe()
 			defer r.Close()
-			defer w.Close()
 			if err != nil {
 				t.Fatal(t, err)
 			}


### PR DESCRIPTION
Port bugfix to 3.1.x

This should have been ported between beta and final 3.1.0... But anyway, let's get it in now so that can be part of 3.1.1