### PR TITLE
MEN-2800: fix erroneously report of "-dirty" in the version string.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-Dockerfile


### PR DESCRIPTION
```
Remove .dockerignore so that the full repo is copied to the image

As the Dockerfile itself was not being sent to the Docker image, git in
the running container will detect it as a deleted file, triggering then
a "-dirty" suffix in the version string.

Changelog: MEN-2800: fix erroneously report of "-dirty" in the version
string.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```