### PR TITLE
Fix build-contained Makefile: image was missing make install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .
 RUN make build
-ENTRYPOINT [ "/go/src/github.com/mendersoftware/mender-artifact/mender-artifact" ]
+RUN make install
+ENTRYPOINT [ "/go/bin/mender-artifact" ]


### PR DESCRIPTION
The Dockerfile for creating mender-artifact image was serving the binary
directly from go/src/..., so the build-contained target was not able to
extract it from the expected go/bin/ directory.

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>