### PR TITLE
MEN-2156: Remove support for Mender-Artifact format version 1

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -165,7 +165,7 @@ func (ar *Reader) readHeader(headerSum []byte, comp artifact.Compressor) error {
 func (ar *Reader) populateArtifactInfo(version int, tr *tar.Reader) error {
 	var hInfo artifact.HeaderInfoer
 	switch version {
-	case 1, 2:
+	case 2:
 		hInfo = new(artifact.HeaderInfo)
 	case 3:
 		hInfo = new(artifact.HeaderInfoV3)
@@ -250,30 +250,6 @@ func (ar *Reader) RegisterHandler(handler handlers.Installer) error {
 
 func (ar *Reader) GetHandlers() map[int]handlers.Installer {
 	return ar.installers
-}
-
-func (ar *Reader) readHeaderV1() error {
-	if ar.shouldBeSigned {
-		return errors.New("reader: expecting signed artifact; " +
-			"v1 is not supporting signatures")
-	}
-	hdr, err := getNext(ar.menderTarReader)
-	if err != nil {
-		return errors.New("reader: error reading header")
-	}
-	if !strings.HasPrefix(hdr.Name, "header.tar") {
-		return errors.Errorf("reader: invalid header element: %v", hdr.Name)
-	}
-
-	comp, err := artifact.NewCompressorFromFileName(hdr.Name)
-	if err != nil {
-		return errors.New("reader: can't get compressor")
-	}
-
-	if err = ar.readHeader(nil, comp); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (ar *Reader) readManifest(name string) error {
@@ -587,7 +563,7 @@ func (ar *Reader) ReadArtifactHeaders() error {
 
 	switch ver.Version {
 	case 1:
-		err = ar.readHeaderV1()
+		err = errors.New("reader: Mender-Artifact version 1 is no longer supported")
 	case 2:
 		err = ar.readHeaderV2(vRaw)
 	case 3:

--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -79,8 +79,6 @@ func MakeRootfsImageArtifact(version int, signed, hasScripts, augmented bool) (i
 
 	var composer, augment handlers.Composer
 	switch version {
-	case 1:
-		composer = handlers.NewRootfsV1(upd)
 	case 2:
 		composer = handlers.NewRootfsV2(upd)
 	case 3:
@@ -208,7 +206,6 @@ func TestReadArtifact(t *testing.T) {
 		verifier  artifact.Verifier
 		readError error
 	}{
-		"version 1":        {1, false, rfh(), nil, nil},
 		"version 2 pass":   {2, false, rfh(), nil, nil},
 		"version 2 signed": {2, true, rfh(), artifact.NewVerifier([]byte(PublicKey)), nil},
 		"version 2 - public key error": {2, true, rfh(), artifact.NewVerifier([]byte(PublicKeyError)),
@@ -286,12 +283,9 @@ func TestReadSigned(t *testing.T) {
 	assert.NoError(t, err)
 
 	art, err = MakeRootfsImageArtifact(1, false, false, false)
-	assert.NoError(t, err)
-	aReader = NewReaderSigned(art)
-	err = aReader.ReadArtifact()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(),
-		"reader: expecting signed artifact")
+		"Unsupported artifact version: 1")
 
 	art, err = MakeRootfsImageArtifact(3, true, false, false)
 	assert.NoError(t, err)
@@ -329,7 +323,7 @@ func TestRegisterMultipleHandlers(t *testing.T) {
 }
 
 func TestReadNoHandler(t *testing.T) {
-	art, err := MakeRootfsImageArtifact(1, false, false, false)
+	art, err := MakeRootfsImageArtifact(2, false, false, false)
 	assert.NoError(t, err)
 
 	aReader := NewReader(art)

--- a/artifact/metadata.go
+++ b/artifact/metadata.go
@@ -75,7 +75,7 @@ type UpdateType struct {
 	Type string `json:"type"`
 }
 
-// HeaderInfoer wraps headerInfo version 1,2 and 3,
+// HeaderInfoer wraps headerInfo version 2 and 3,
 // in order to supply the artifact reader with the information it needs.
 type HeaderInfoer interface {
 	Write(b []byte) (n int, err error)
@@ -162,8 +162,8 @@ func (hi *HeaderInfo) GetArtifactProvides() *ArtifactProvides {
 
 type HeaderInfoV3 struct {
 	// For historical reasons, "payloads" are often referred to as "updates"
-	// in the code, since this was the old name (and still is, in V2 and
-	// V1). This is the reason why the struct field is still called
+	// in the code, since this was the old name (and still is, in V2).
+	// This is the reason why the struct field is still called
 	// "Updates".
 	Updates          []UpdateType      `json:"payloads"`
 	ArtifactProvides *ArtifactProvides `json:"artifact_provides"` // Has its own json marshaller tags.

--- a/artifact/metadata_test.go
+++ b/artifact/metadata_test.go
@@ -31,10 +31,10 @@ func TestValidateInfo(t *testing.T) {
 		err error
 	}{
 		{Info{Format: "", Version: 0}, ErrValidatingData},
-		{Info{Format: "", Version: 1}, ErrValidatingData},
+		{Info{Format: "", Version: 2}, ErrValidatingData},
 		{Info{Format: "format"}, ErrValidatingData},
 		{Info{}, ErrValidatingData},
-		{Info{Format: "format", Version: 1}, nil},
+		{Info{Format: "format", Version: 2}, nil},
 	}
 
 	for _, tt := range validateTests {

--- a/awriter/writer.go
+++ b/awriter/writer.go
@@ -118,7 +118,7 @@ func writeTempHeader(c artifact.Compressor, manifestChecksumStore *artifact.Chec
 		htw := tar.NewWriter(gz)
 		defer htw.Close()
 
-		// Header differs in version 3 from version 1 and 2.
+		// Header differs in version 3 from version 2.
 		if err = writeHeader(htw, args, augmented); err != nil {
 			return errors.Wrapf(err, "writer: error writing header")
 		}
@@ -167,22 +167,23 @@ type WriteArtifactArgs struct {
 }
 
 func (aw *Writer) WriteArtifact(args *WriteArtifactArgs) (err error) {
-	if !(args.Version == 1 || args.Version == 2 || args.Version == 3) {
-		return errors.New("Unsupported artifact version")
+
+	if args.Version == 1 {
+		return errors.New("writer: The Mender-Artifact version 1 is outdated. Refusing to create artifact.")
 	}
 
-	if args.Version == 1 && aw.signer != nil {
-		return errors.New("writer: can not create version 1 signed artifact")
+	if !(args.Version == 2 || args.Version == 3) {
+		return errors.New("Unsupported artifact version")
 	}
 
 	if args.Version == 3 {
 		return aw.writeArtifactV3(args)
 	}
 
-	return aw.writeArtifactV1V2(args)
+	return aw.writeArtifactV2(args)
 }
 
-func (aw *Writer) writeArtifactV1V2(args *WriteArtifactArgs) error {
+func (aw *Writer) writeArtifactV2(args *WriteArtifactArgs) error {
 
 	manifestChecksumStore := artifact.NewChecksumStore()
 	// calculate checksums of all data files
@@ -352,8 +353,6 @@ func writeManifestVersion(version int, signer artifact.Signer, tw *tar.Writer, m
 				return errors.Wrapf(err, "writer: can not write manifest stream")
 			}
 		}
-	case 1:
-
 	default:
 		return fmt.Errorf("writer: unsupported artifact version: %d", version)
 	}

--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -239,7 +239,7 @@ func repack(comp artifact.Compressor, artifactName string, from io.Reader, to io
 	var h *handlers.Rootfs
 	switch info.Version {
 	case 1:
-		h = handlers.NewRootfsV1(data)
+		return nil, errors.New("Mender-Artifact version 1 no longer supported")
 	case 2:
 		h = handlers.NewRootfsV2(data)
 	case 3:

--- a/cli/mender-artifact/artifacts_test.go
+++ b/cli/mender-artifact/artifacts_test.go
@@ -80,7 +80,7 @@ func WriteTestArtifact(version int, update string, key []byte) (io.Reader, error
 		defer os.Remove(update)
 	}
 
-	rfs := handlers.NewRootfsV1(update)
+	rfs := handlers.NewRootfsV2(update)
 
 	switch version {
 	case 1:
@@ -134,7 +134,7 @@ func WriteArtifact(dir string, ver int, update string) error {
 	}
 	defer f.Close()
 
-	u := handlers.NewRootfsV1(update)
+	u := handlers.NewRootfsV2(update)
 
 	aw := awriter.NewWriter(f, comp)
 	switch ver {
@@ -306,7 +306,7 @@ func TestArtifactsSigned(t *testing.T) {
 	fakeErrWriter.Reset()
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "writer: can not create version 1 signed artifact\n",
+	assert.Equal(t, "Error: Mender-Artifact version 1 is not supported\n",
 		fakeErrWriter.String())
 }
 

--- a/cli/mender-artifact/read_test.go
+++ b/cli/mender-artifact/read_test.go
@@ -33,7 +33,7 @@ func TestArtifactsRead(t *testing.T) {
 	updateTestDir, _ := ioutil.TempDir("", "update")
 	defer os.RemoveAll(updateTestDir)
 
-	err := WriteArtifact(updateTestDir, 1, "")
+	err := WriteArtifact(updateTestDir, 2, "")
 	assert.NoError(t, err)
 
 	os.Args = []string{"mender-artifact", "read"}

--- a/cli/mender-artifact/sign_test.go
+++ b/cli/mender-artifact/sign_test.go
@@ -22,44 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mendersoftware/mender-artifact/awriter"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestSignExistingV1(t *testing.T) {
-	// first create archive, that we will be able to read
-	updateTestDir, _ := ioutil.TempDir("", "update")
-	defer os.RemoveAll(updateTestDir)
-
-	priv, pub, err := generateKeys()
-	assert.NoError(t, err)
-
-	err = WriteArtifact(updateTestDir, 1, "")
-	assert.NoError(t, err)
-
-	err = MakeFakeUpdateDir(updateTestDir,
-		[]TestDirEntry{
-			{
-				Path:    "private.key",
-				Content: priv,
-				IsDir:   false,
-			},
-			{
-				Path:    "public.key",
-				Content: pub,
-				IsDir:   false,
-			},
-		})
-	assert.NoError(t, err)
-
-	os.Args = []string{"mender-artifact", "sign",
-		"-k", filepath.Join(updateTestDir, "private.key"),
-		filepath.Join(updateTestDir, "artifact.mender")}
-
-	err = run()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), awriter.ErrManifestNotFound.Error())
-}
 
 func TestSignExistingV2(t *testing.T) {
 	// first create archive, that we will be able to read

--- a/cli/mender-artifact/validate_test.go
+++ b/cli/mender-artifact/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ var validateTests = []struct {
 	validateKey   []byte
 	expectedError error
 }{
-	{1, nil, nil, nil},
+	{2, nil, nil, nil},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKey), nil},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKeyError),
 		ErrInvalidSignature},
@@ -97,7 +97,7 @@ func TestArtifactsValidate(t *testing.T) {
 	updateTestDir, _ := ioutil.TempDir("", "update")
 	defer os.RemoveAll(updateTestDir)
 
-	err := WriteArtifact(updateTestDir, 1, "")
+	err := WriteArtifact(updateTestDir, 2, "")
 	assert.NoError(t, err)
 
 	os.Args = []string{"mender-artifact", "validate",

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -28,7 +28,7 @@ import (
 )
 
 func validateInput(c *cli.Context) error {
-	// Version 1,2 and 3 validation.
+	// Version 2 and 3 validation.
 	if len(c.StringSlice("device-type")) == 0 ||
 		len(c.String("artifact-name")) == 0 ||
 		len(c.String("file")) == 0 {
@@ -70,7 +70,7 @@ func writeRootfs(c *cli.Context) error {
 	var h handlers.Composer
 	switch version {
 	case 1:
-		h = handlers.NewRootfsV1(c.String("file"))
+		return cli.NewExitError("Error: Mender-Artifact version 1 is not supported", errArtifactUnsupportedVersion)
 	case 2:
 		h = handlers.NewRootfsV2(c.String("file"))
 	case 3:
@@ -105,9 +105,6 @@ func writeRootfs(c *cli.Context) error {
 	scr, err := scripts(c.StringSlice("script"))
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
-	} else if len(scr.Get()) != 0 && version == 1 {
-		// check if we are having correct version
-		return cli.NewExitError("can not use scripts artifact with version 1", 1)
 	}
 
 	depends := artifact.ArtifactDepends{
@@ -176,7 +173,7 @@ func makeUpdates(ctx *cli.Context) (*awriter.Updates, error) {
 
 	var handler, augmentHandler handlers.Composer
 	switch version {
-	case 1, 2:
+	case 2:
 		return nil, cli.NewExitError(
 			"Module images need at least artifact format version 3",
 			errArtifactInvalidParameters)
@@ -328,6 +325,10 @@ func writeModuleImage(ctx *cli.Context) error {
 	}
 	version := ctx.Int("version")
 
+	if version == 1 {
+		return cli.NewExitError("Mender-Artifact version 1 is not supported", 1)
+	}
+
 	upd, err := makeUpdates(ctx)
 	if err != nil {
 		return err
@@ -352,9 +353,6 @@ func writeModuleImage(ctx *cli.Context) error {
 	scr, err := scripts(ctx.StringSlice("script"))
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
-	} else if len(scr.Get()) != 0 && version == 1 {
-		// check if we are having correct version
-		return cli.NewExitError("can not use scripts artifact with version 1", 1)
 	}
 
 	depends := artifact.ArtifactDepends{

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -61,13 +61,6 @@ func TestArtifactsWrite(t *testing.T) {
 	err = run()
 	assert.Equal(t, "whitespace is not allowed in the artifact-name", err.Error())
 
-	// store named file V1.
-	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
-		"-n", "mender-1.1", "-f", filepath.Join(updateTestDir, "update.ext4"),
-		"-o", filepath.Join(updateTestDir, "art.mender"), "-v", "1"}
-	err = run()
-	assert.NoError(t, err)
-
 	// store named file V2.
 	os.Args = []string{"mender-artifact", "write", "rootfs-image", "-t", "my-device",
 		"-n", "mender-1.1", "-f", filepath.Join(updateTestDir, "update.ext4"),
@@ -163,7 +156,7 @@ func TestWithScripts(t *testing.T) {
 	fakeErrWriter.Reset()
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "can not use scripts artifact with version 1\n",
+	assert.Equal(t, "Error: Mender-Artifact version 1 is not supported\n",
 		fakeErrWriter.String())
 
 	// write artifact vith invalid script name
@@ -307,4 +300,15 @@ func TestWriteModuleImage(t *testing.T) {
 	metaData, err := handler.GetUpdateMetaData()
 	require.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"metadata": "augment"}, metaData)
+
+	os.Args = []string{
+		"mender-artifact",
+		"write",
+		"module-image",
+		"-v", "1",
+		"-f", "foobar",
+	}
+
+	err = reader.ReadArtifact()
+	assert.Error(t, err)
 }

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -236,14 +236,3 @@ func writeTypeInfoV3(args *WriteInfoArgs) error {
 	}
 	return nil
 }
-
-func writeChecksums(tw *tar.Writer, files [](*DataFile), dir string) error {
-	for _, f := range files {
-		w := artifact.NewTarWriterStream(tw)
-		if err := w.Write(f.Checksum,
-			filepath.Join(dir, filepath.Base(f.Name)+".sha256sum")); err != nil {
-			return errors.Wrapf(err, "Payload: can not tar checksum for %v", f)
-		}
-	}
-	return nil
-}

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -40,16 +40,6 @@ type Rootfs struct {
 	installerBase
 }
 
-func NewRootfsV1(updFile string) *Rootfs {
-	uf := &DataFile{
-		Name: updFile,
-	}
-	return &Rootfs{
-		update:  uf,
-		version: 1,
-	}
-}
-
 func NewRootfsV2(updFile string) *Rootfs {
 	uf := &DataFile{
 		Name: updFile,
@@ -368,13 +358,6 @@ func (rfs *Rootfs) ComposeHeader(args *ComposeHeaderArgs) error {
 		return errors.Wrap(err, "Payload: can not store meta-data")
 	}
 
-	if rfs.version == 1 {
-		// store checksums
-		if err := writeChecksums(args.TarWriter, [](*DataFile){rfs.update},
-			filepath.Join(path, "checksums")); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/handlers/rootfs_image_test.go
+++ b/handlers/rootfs_image_test.go
@@ -28,15 +28,7 @@ import (
 
 func TestHandlerRootfs(t *testing.T) {
 	// test if update type is reported correctly
-	r := NewRootfsV1("")
-	require.Equal(t, "rootfs-image", r.GetUpdateType())
-
-	// test get update files
-	r.update = &DataFile{Name: "update.ext4"}
-	require.Equal(t, "update.ext4", r.GetUpdateFiles()[0].Name)
-	require.Equal(t, 1, r.version)
-
-	r = NewRootfsV2("")
+	r := NewRootfsV2("")
 	require.Equal(t, "rootfs-image", r.GetUpdateType())
 
 	// test get update files
@@ -57,7 +49,7 @@ func (t *TestErrWriter) Write(b []byte) (n int, err error) {
 
 func TestRootfsReadHeader(t *testing.T) {
 	var r Installer
-	r = NewRootfsV1("custom")
+	r = NewRootfsV2("custom")
 
 	tc := []struct {
 		version            int
@@ -134,7 +126,7 @@ func TestRootfsReadHeader(t *testing.T) {
 			}
 
 			if test.version < 3 {
-				// Done for version 1 and 2
+				// Done for 2
 				return
 			}
 
@@ -164,11 +156,6 @@ func TestComposeHeader(t *testing.T) {
 			args: ComposeHeaderArgs{Version: -1},
 			err:  errors.New("ComposeHeader: rootfs-version 0 not supported"),
 		},
-		"version 1 - no tar writer": {
-			rfs:  NewRootfsV1(""),
-			args: ComposeHeaderArgs{},
-			err:  errors.New("writer: tar-writer is nil"),
-		},
 		"version 2 - no tar writer": {
 			rfs:  NewRootfsV2(""),
 			args: ComposeHeaderArgs{},
@@ -178,13 +165,6 @@ func TestComposeHeader(t *testing.T) {
 			rfs:  NewRootfsV3(""),
 			args: ComposeHeaderArgs{},
 			err:  errors.New("ComposeHeader: Payload: can not tar type-info: arch: Can not write to empty tar-writer"),
-		},
-		"version 1 - success": { // TODO - should this succeed with no update files?
-			rfs: NewRootfsV1(""),
-			args: ComposeHeaderArgs{
-				TarWriter: tar.NewWriter(bytes.NewBuffer(nil)),
-			},
-			err: nil,
 		},
 		"version 3 - success": {
 			rfs: NewRootfsV3(""),
@@ -203,7 +183,7 @@ func TestComposeHeader(t *testing.T) {
 			verifyFunc: func(args ComposeHeaderArgs) { assert.Nil(t, args.TypeInfoV3) },
 		},
 		"error: metadata not empty": {
-			rfs: NewRootfsV1(""),
+			rfs: NewRootfsV2(""),
 			args: ComposeHeaderArgs{
 				TarWriter: tar.NewWriter(bytes.NewBuffer(nil)),
 				MetaData:  map[string]interface{}{"foo": "bar"},


### PR DESCRIPTION
Changelog: Mender-Artifact format version 1 is hereby deprecated,
and neither reading or writing the version 1 of the format is no longer
supported. Please move to using a newer version.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>