### PR TITLE
Update the type-info documentation in the version 3 artifact format

### DIFF
--- a/Documentation/artifact-format-v3.md
+++ b/Documentation/artifact-format-v3.md
@@ -270,19 +270,16 @@ As an opposite to the list of global `artifact_provides` being a part of
 `header-info` file, the `artifact_provides` section in the `type-info` file
 is a set of parameters specific for a given payload type.
 
-The list of currently supported parameters is as follows:
-
-* `rootfs_image_checksum` is the checksum of the image contained within the
-  Artifact
+The `artifact_provides` is a key-value store, where the value is either a string,
+or an array of strings.
 
 #### artifact_depends
 
 The `artifact_depends` section in the `type-info` file is a set of parameters
-specific for a given payload type. The list of currently supported
-parameters is as follows:
+specific for a given payload type.
 
-* `rootfs_image_checksum` is the checksum of the image that needs to be installed
-on the device before current Artifact can be installed
+The `artifact_depends` is a key-value store, where the value is either a string,
+or an array of strings.
 
 
 ### meta-data
@@ -381,11 +378,6 @@ These files and attributes are allowed:
     },
   }
   ```
-
-At the moment ONLY a `type-info` file is allowed which can contain only
-`artifact_depends` with one field: `rootfs_image_checksum` parameters and type
-of the payload.
-
 
 data
 ----


### PR DESCRIPTION
This commit updates the description of the values allowed in the type-info
headers in the version 3 of the artifact format. Formerly only the key
`rootfs-image-checksum` was allowed, while now, any key is allowed, with
the only allowed value types being string, or array of strings.

Changelog: Commit

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>