### PR TITLE
MEN-2802: Do not validate signed Artiafcts without a key

### DIFF
--- a/cli/mender-artifact/validate.go
+++ b/cli/mender-artifact/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -26,8 +26,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var ErrInvalidSignature = errors.New("error validating signature")
-
 func validate(art io.Reader, key []byte) error {
 	// do not return error immediately if we can not validate signature;
 	// just continue checking consistency and return info if
@@ -52,12 +50,13 @@ func validate(art io.Reader, key []byte) error {
 		return err
 	}
 	if validationError != nil {
-		Log.Debugf("error validating signature: %s", validationError.Error())
-		return ErrInvalidSignature
+		return validationError
 	}
 	if keyIsSpecified && !ar.IsSigned {
-		Log.Debug("key was specified but no digital signature was found")
-		return ErrInvalidSignature
+		return errors.New("missing signature")
+	}
+	if !keyIsSpecified && ar.IsSigned {
+		return errors.New("missing key")
 	}
 	return nil
 }

--- a/cli/mender-artifact/validate_test.go
+++ b/cli/mender-artifact/validate_test.go
@@ -64,16 +64,16 @@ var validateTests = []struct {
 	version       int
 	writeKey      []byte
 	validateKey   []byte
-	expectedError error
+	expectedError string
 }{
-	{2, nil, nil, nil},
-	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKey), nil},
+	{2, nil, nil, ""},
+	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKey), ""},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKeyError),
-		ErrInvalidSignature},
+		"verification error"},
 	{2, []byte(PrivateValidateRSAKey), []byte(PublicValidateRSAKeyInvalid),
-		ErrInvalidSignature},
-	{2, []byte(PrivateValidateRSAKey), nil, nil},
-	{2, nil, []byte(PublicValidateRSAKey), ErrInvalidSignature}, // MEN-2155
+		"failed to parse public key"},
+	{2, []byte(PrivateValidateRSAKey), nil, "missing key"}, // MEN-2802
+	{2, nil, []byte(PublicValidateRSAKey), "missing signature"}, // MEN-2155
 }
 
 func TestValidate(t *testing.T) {
@@ -82,11 +82,11 @@ func TestValidate(t *testing.T) {
 		art, err := WriteTestArtifact(test.version, "", test.writeKey)
 		assert.NoError(t, err)
 		err = validate(art, test.validateKey)
-		if test.expectedError == nil {
+		if test.expectedError == "" {
 			assert.NoError(t, err)
 		} else {
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), test.expectedError.Error())
+			assert.Contains(t, err.Error(), test.expectedError)
 		}
 		fmt.Println("---------------------------------")
 	}


### PR DESCRIPTION
Changelog: mender-artifact will now fail to validate a signed artifact
if no validation key is specified. No behaviour change for unsigned
artifacts.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>