### PR TITLE
Enable typeinfo artifact-depends/provides string and []string values

### DIFF
--- a/artifact/metadata.go
+++ b/artifact/metadata.go
@@ -17,6 +17,7 @@ package artifact
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
@@ -287,9 +288,105 @@ func (ti *TypeInfo) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-type TypeInfoDepends map[string]string
+type TypeInfoDepends map[string]interface{}
 
-type TypeInfoProvides map[string]string
+func (t TypeInfoDepends) Map() map[string]interface{} {
+	return map[string]interface{}(t)
+}
+
+func NewTypeInfoDepends(m interface{}) (ti TypeInfoDepends, err error) {
+	ti = make(map[string]interface{})
+	switch m.(type) {
+	case map[string]interface{}:
+		m := m.(map[string]interface{})
+		for k, v := range m {
+			switch v.(type) {
+			case string, []string:
+				ti[k] = v
+				continue
+			default:
+				return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+			}
+		}
+		return ti, nil
+	case map[string]string:
+		m := m.(map[string]string)
+		for k, v := range m {
+			ti[k] = v
+		}
+		return ti, nil
+	case map[string][]string:
+		m := m.(map[string][]string)
+		for k, v := range m {
+			ti[k] = v
+		}
+		return ti, nil
+	default:
+		return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+	}
+}
+
+// UnmarshalJSON attempts to deserialize the json stream into a 'map[string]interface{}',
+// where each interface value is required to be either a string, or an array of strings
+func (t *TypeInfoDepends) UnmarshalJSON(b []byte) error {
+	m := make(map[string]interface{})
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+	*t, err = NewTypeInfoDepends(m)
+	return err
+}
+
+type TypeInfoProvides map[string]interface{}
+
+func (t TypeInfoProvides) Map() map[string]interface{} {
+	return map[string]interface{}(t)
+}
+
+func NewTypeInfoProvides(m interface{}) (ti TypeInfoProvides, err error) {
+	ti = make(map[string]interface{})
+	switch m.(type) {
+	case map[string]interface{}:
+		m := m.(map[string]interface{})
+		for k, v := range m {
+			switch v.(type) {
+			case string, []string:
+				ti[k] = v
+				continue
+			default:
+				return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+			}
+		}
+		return ti, nil
+	case map[string]string:
+		m := m.(map[string]string)
+		for k, v := range m {
+			ti[k] = v
+		}
+		return ti, nil
+	case map[string][]string:
+		m := m.(map[string][]string)
+		for k, v := range m {
+			ti[k] = v
+		}
+		return ti, nil
+	default:
+		return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+	}
+}
+
+// UnmarshalJSON attempts to deserialize the json stream into a 'map[string]interface{}',
+// where each interface value is required to be either a string, or an array of strings
+func (t *TypeInfoProvides) UnmarshalJSON(b []byte) error {
+	m := make(map[string]interface{})
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+	*t, err = NewTypeInfoProvides(m)
+	return err
+}
 
 // TypeInfoV3 provides information about the type of update contained within the
 // headerstructure.

--- a/artifact/metadata_test.go
+++ b/artifact/metadata_test.go
@@ -418,3 +418,81 @@ func TestHeaderInfo(t *testing.T) {
 	assert.Equal(t, hi.Updates[0].Type, "rootfs-image")
 	assert.Equal(t, hi.GetCompatibleDevices()[0], "vexpress-qemu")
 }
+
+func TestNewTypeInfoSuccess(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		err   error
+	}{
+		{
+			name: "Valid: map[string]string",
+			input: map[string]string{
+				"foo": "bar",
+			},
+			err: nil,
+		},
+		{
+			name: "Valid: map[string][]string",
+			input: map[string][]string{
+				"foo": []string{"bar", "baz"},
+			},
+			err: nil,
+		},
+		{
+			name: "Valid: map[string]interface{}",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"bar": []string{
+					"boo", "baz",
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, test := range tests {
+		ti, err := NewTypeInfoDepends(test.input)
+		assert.Equal(t, err, test.err)
+		assert.NotNil(t, ti)
+
+		tip, err := NewTypeInfoProvides(test.input)
+		assert.Equal(t, err, test.err)
+		assert.NotNil(t, tip)
+	}
+}
+
+func TestNewTypeInfoError(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		err   error
+	}{
+		{
+			name: "Invalid: map[string]int",
+			input: map[string]int{
+				"foo": 1,
+			},
+		},
+		{
+			name: "Invalid: map[string]interface{} with invalid value",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"bar": []string{
+					"boo", "baz",
+				},
+				"baz": 1,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		ti, err := NewTypeInfoDepends(test.input)
+		assert.NotNil(t, err)
+		assert.Nil(t, ti)
+
+		tip, err := NewTypeInfoProvides(test.input)
+		assert.NotNil(t, err)
+		assert.Nil(t, tip)
+	}
+}

--- a/cli/mender-artifact/read.go
+++ b/cli/mender-artifact/read.go
@@ -114,7 +114,7 @@ func readArtifact(c *cli.Context) error {
 	return nil
 }
 
-func sortedKeys(mapWithKeys map[string]string) sort.StringSlice {
+func sortedKeys(mapWithKeys map[string]interface{}) sort.StringSlice {
 	var keys sort.StringSlice = make([]string, 0, len(mapWithKeys))
 	for key := range mapWithKeys {
 		keys = append(keys, key)

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -217,46 +217,50 @@ func makeTypeInfo(ctx *cli.Context) (*artifact.TypeInfoV3, *artifact.TypeInfoV3,
 	// line.
 	var keyValues *map[string]string
 
-	var typeInfoDepends *artifact.TypeInfoDepends
+	var typeInfoDepends artifact.TypeInfoDepends
 	keyValues, err := extractKeyValues(ctx.StringSlice("depends"))
 	if err != nil {
 		return nil, nil, err
 	} else if keyValues != nil {
-		typeInfoDepends = new(artifact.TypeInfoDepends)
-		*typeInfoDepends = *keyValues
+		if typeInfoDepends, err = artifact.NewTypeInfoDepends(*keyValues); err != nil {
+			return nil, nil, err
+		}
 	}
 
-	var typeInfoProvides *artifact.TypeInfoProvides
+	var typeInfoProvides artifact.TypeInfoProvides
 	keyValues, err = extractKeyValues(ctx.StringSlice("provides"))
 	if err != nil {
 		return nil, nil, err
 	} else if keyValues != nil {
-		typeInfoProvides = new(artifact.TypeInfoProvides)
-		*typeInfoProvides = *keyValues
+		if typeInfoProvides, err = artifact.NewTypeInfoProvides(*keyValues); err != nil {
+			return nil, nil, err
+		}
 	}
 
-	var augmentTypeInfoDepends *artifact.TypeInfoDepends
+	var augmentTypeInfoDepends artifact.TypeInfoDepends
 	keyValues, err = extractKeyValues(ctx.StringSlice("augment-depends"))
 	if err != nil {
 		return nil, nil, err
 	} else if keyValues != nil {
-		augmentTypeInfoDepends = new(artifact.TypeInfoDepends)
-		*augmentTypeInfoDepends = *keyValues
+		if augmentTypeInfoDepends, err = artifact.NewTypeInfoDepends(*keyValues); err != nil {
+			return nil, nil, err
+		}
 	}
 
-	var augmentTypeInfoProvides *artifact.TypeInfoProvides
+	var augmentTypeInfoProvides artifact.TypeInfoProvides
 	keyValues, err = extractKeyValues(ctx.StringSlice("augment-provides"))
 	if err != nil {
 		return nil, nil, err
 	} else if keyValues != nil {
-		augmentTypeInfoProvides = new(artifact.TypeInfoProvides)
-		*augmentTypeInfoProvides = *keyValues
+		if augmentTypeInfoProvides, err = artifact.NewTypeInfoProvides(*keyValues); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	typeInfoV3 := &artifact.TypeInfoV3{
 		Type:             ctx.String("type"),
-		ArtifactDepends:  typeInfoDepends,
-		ArtifactProvides: typeInfoProvides,
+		ArtifactDepends:  &typeInfoDepends,
+		ArtifactProvides: &typeInfoProvides,
 	}
 
 	if ctx.String("augment-type") == "" {
@@ -275,8 +279,8 @@ func makeTypeInfo(ctx *cli.Context) (*artifact.TypeInfoV3, *artifact.TypeInfoV3,
 
 	augmentTypeInfoV3 := &artifact.TypeInfoV3{
 		Type:             ctx.String("augment-type"),
-		ArtifactDepends:  augmentTypeInfoDepends,
-		ArtifactProvides: augmentTypeInfoProvides,
+		ArtifactDepends:  &augmentTypeInfoDepends,
+		ArtifactProvides: &augmentTypeInfoProvides,
 	}
 
 	return typeInfoV3, augmentTypeInfoV3, nil


### PR DESCRIPTION
Previously the artifact-depends key in the type-info header was restricted
to contain a single key `rootfs-image-checksum`. This restriction has now
been lifted, and the key can now contain arbitrary string, and []string values.

Changelog: Commit

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>