### PR TITLE
MEN-2812: Enables Artifact Provides and Depends for write rootfs-img

### DIFF
--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -79,7 +79,7 @@ func getCliContext() *cli.App {
 	compressors := artifact.GetRegisteredCompressorIds()
 
 	compressionFlag := cli.StringFlag{
-		Name:  "compression",
+		Name: "compression",
 		Usage: fmt.Sprintf("Compression to use for data and header inside the artifact, "+
 			"currently supports: %v.", strings.Join(compressors, ", ")),
 	}
@@ -97,6 +97,30 @@ func getCliContext() *cli.App {
 		Name: "key, k",
 		Usage: "Full path to the public key that will be used to verify " +
 			"the artifact signature.",
+	}
+
+	//
+	// Common Artifact Depends and Provides flags
+	//
+	artifactNameDepends := cli.StringSliceFlag{
+		Name:  "artifact-name-depends, N",
+		Usage: "Sets the name(s) of the artifact(s) which this update depends upon",
+	}
+	artifactProvides := cli.StringSliceFlag{
+		Name:  "provides, p",
+		Usage: "Generic `KEY:VALUE` which is added to the type-info -> artifact_provides section. Can be given multiple times",
+	}
+	artifactDepends := cli.StringSliceFlag{
+		Name:  "depends, d",
+		Usage: "Generic `KEY:VALUE` which is added to the type-info -> artifact_depends section. Can be given multiple times",
+	}
+	artifactProvidesGroup := cli.StringFlag{
+		Name:  "provides-group, g",
+		Usage: "The group the artifact provides",
+	}
+	artifactDependsGroups := cli.StringSliceFlag{
+		Name:  "depends-groups, G",
+		Usage: "The group(s) the artifact depends on",
 	}
 
 	//
@@ -141,30 +165,11 @@ func getCliContext() *cli.App {
 		/////////////////////////
 		// Version 3 specifics.//
 		/////////////////////////
-		// Hiding these for now. We are not enforcing them on the client
-		// so we should not set these yet.
-		//
-		// cli.StringSliceFlag{
-		// 	Name:  "artifact-name-depends, N",
-		// 	Usage: "Sets the name(s) of the artifact(s) which this update depends upon",
-		// },
-		// cli.StringFlag{
-		// 	Name:  "provides-group, g",
-		// 	Usage: "The group the artifact provides",
-		// },
-		// cli.StringSliceFlag{
-		// 	Name:  "depends-groups, G",
-		// 	Usage: "The group(s) the artifact depends on",
-		// },
-		// cli.StringFlag{
-		// 	Name:  "depends-rootfs-image-checksum",
-		// 	Usage: "The checksum of the rootfs image which this artifact depends upon",
-		// },
-		// cli.StringFlag{
-		// 	Name:  "provides-rootfs-image-checksum",
-		// 	Usage: "The checksum of the rootfs image which this artifact provides",
-		// },
-
+		artifactNameDepends,
+		artifactDepends,
+		artifactProvides,
+		artifactProvidesGroup,
+		artifactDependsGroups,
 		compressionFlag,
 	}
 	writeRootfsCommand.Before = applyCompressionInCommand
@@ -210,29 +215,14 @@ func getCliContext() *cli.App {
 			Usage: "Full path to the state script(s). You can specify multiple " +
 				"scripts providing this parameter multiple times.",
 		},
-		cli.StringSliceFlag{
-			Name:  "artifact-name-depends, N",
-			Usage: "Sets the name(s) of the artifact(s) which this update depends upon",
-		},
-		cli.StringFlag{
-			Name:  "provides-group, g",
-			Usage: "The group the artifact provides",
-		},
-		cli.StringSliceFlag{
-			Name:  "depends-groups, G",
-			Usage: "The group(s) the artifact depends on",
-		},
+		artifactNameDepends,
+		artifactDepends,
+		artifactProvides,
+		artifactProvidesGroup,
+		artifactDependsGroups,
 		cli.StringFlag{
 			Name:  "type, T",
 			Usage: "Type of payload. This is the same as the name of the update module",
-		},
-		cli.StringSliceFlag{
-			Name:  "provides, p",
-			Usage: "Generic `KEY:VALUE` which is added to the type-info -> artifact_provides section. Can be given multiple times",
-		},
-		cli.StringSliceFlag{
-			Name:  "depends, d",
-			Usage: "Generic `KEY:VALUE` which is added to the type-info -> artifact_depends section. Can be given multiple times",
 		},
 		cli.StringFlag{
 			Name:  "meta-data, m",

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -118,14 +118,9 @@ func writeRootfs(c *cli.Context) error {
 		ArtifactGroup: c.String("provides-group"),
 	}
 
-	typeInfoV3 := artifact.TypeInfoV3{
-		Type: "rootfs-image",
-		// Keeping these empty for now. We will likely introduce these
-		// later, when we add support for augmented artifacts.
-		// ArtifactDepends:  &artifact.TypeInfoDepends{"rootfs_image_checksum": c.String("depends-rootfs-image-checksum")},
-		// ArtifactProvides: &artifact.TypeInfoProvides{"rootfs_image_checksum": c.String("provides-rootfs-image-checksum")},
-		ArtifactDepends:  &artifact.TypeInfoDepends{},
-		ArtifactProvides: &artifact.TypeInfoProvides{},
+	typeInfoV3, _, err := makeTypeInfo(c)
+	if err != nil {
+		return err
 	}
 
 	err = aw.WriteArtifact(
@@ -138,7 +133,7 @@ func writeRootfs(c *cli.Context) error {
 			Scripts:    scr,
 			Depends:    &depends,
 			Provides:   &provides,
-			TypeInfoV3: &typeInfoV3,
+			TypeInfoV3: typeInfoV3,
 		})
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)


### PR DESCRIPTION
Previously, the `write rootfs-image` command did not have the ability
to set Provides and Depends in the artifact. This was only enabled for
the `write module-image` command. Now the `rootfs-image` update can
also set Provides and Depends. However, please note that meta-data
and augmented Provides and Depends still are unsupported.

Changelog: commit

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>