### PR TITLE
[Cherry] MEN-2880: Make artifact install respect the given file permissions

### DIFF
--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -17,7 +17,9 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/mendersoftware/mender-artifact/artifact"
@@ -132,8 +134,6 @@ func Install(c *cli.Context) (err error) {
 		return cli.NewExitError("compressor '"+c.GlobalString("compression")+"' is not supported: "+err.Error(), 1)
 	}
 
-	var r io.ReadCloser
-	var w io.WriteCloser
 	wclose := func(w io.Closer) {
 		if w == nil {
 			return
@@ -150,19 +150,32 @@ func Install(c *cli.Context) (err error) {
 			return cli.NewExitError("File permissions needs to be set, if you are simply copying, the cp command should fit your needs", 1)
 		}
 		perm = os.FileMode(c.Int("mode"))
-		r, err = os.OpenFile(c.Args().First(), os.O_RDWR, perm)
-		defer r.Close()
+		f, err := os.Open(c.Args().First())
+		defer f.Close()
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
 		}
-		f, err := virtualPartitionFile.Open(comp, c.Args().Get(1))
-		defer wclose(f)
+		vfile, err := virtualPartitionFile.Open(comp, c.Args().Get(1))
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
 		}
-		w = f
-		if _, err = io.Copy(w, r); err != nil {
+		defer wclose(vfile)
+
+		tfName, err := createTmpFileWithPerm(f, perm)
+		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%v", err), 1)
+		}
+
+		Log.Debugf("Created tempfile: %s", tfName)
+		defer func() {
+			lerr := os.RemoveAll(filepath.Dir(tfName))
+			if lerr != nil {
+				Log.Warnf("Failed to remove tmpdir with: %v", lerr)
+			}
+		}()
+
+		if err = vfile.CopyTo(tfName); err != nil {
+			return cli.NewExitError(err, 1)
 		}
 		return nil
 	case parseError:
@@ -243,4 +256,47 @@ func parseCLIOptions(c *cli.Context) int {
 		}
 		return parseError
 	}
+}
+
+// createTmpFileWithPerm Takes a file, and creates a temp-file copy of the
+// current file, with the permissions given by perm.
+func createTmpFileWithPerm(f *os.File, perm os.FileMode) (string, error) {
+
+	td, err := ioutil.TempDir("", "mender-artifact-install")
+	if err != nil {
+		return "", err
+	}
+
+	tf, err := os.OpenFile(filepath.Join(td,
+		filepath.Base(f.Name())), os.O_CREATE|os.O_WRONLY, perm)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = io.Copy(tf, f)
+	if err != nil {
+		return "", err
+	}
+
+	// override umask
+	err = tf.Chmod(perm)
+	if err != nil {
+		return "", err
+	}
+
+	name := tf.Name()
+	Log.Debugf("Tempfile name: %s\n", name)
+
+	s, _ := tf.Stat()
+	err = tf.Close()
+	if err != nil {
+		return "", err
+	}
+
+	if s != nil {
+		Log.Debugf("The tempfile: %s got permissions: %v\noriginal-permissions: %s\n",
+			name, s.Mode(), perm)
+	}
+
+	return name, nil
 }

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -301,7 +301,7 @@ func TestCopyRootfsImage(t *testing.T) {
 					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
 					out, err := cmd.CombinedOutput()
 					require.Nil(t, err)
-					require.True(t, strings.Contains(string(out), "Mode:  0600"))
+					assert.True(t, strings.Contains(string(out), "Mode:  0600"))
 				case sdimgFile:
 					imgpath := pf.(sdimgFile)[0].(*extFile).path
 					bin, err := utils.GetBinaryPath("debugfs")
@@ -309,7 +309,95 @@ func TestCopyRootfsImage(t *testing.T) {
 					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
 					out, err := cmd.CombinedOutput()
 					require.Nil(t, err)
-					require.True(t, strings.Contains(string(out), "Mode:  0600"))
+					assert.True(t, strings.Contains(string(out), "Mode:  0600"))
+				default:
+					t.Fatal("Unexpected file type")
+				}
+			},
+		},
+		{
+			name: "Install file with permissions (0777)",
+			initfunc: func(imgpath string) {
+				require.Nil(t, ioutil.WriteFile("testkey", []byte("foobar"), 0644))
+			},
+			argv: []string{"mender-artifact", "install", "-m", "0777", "testkey", "<artifact|sdimg|fat-sdimg>:/etc/mender/testkey.key"},
+			verifyTestFunc: func(imgpath string) {
+				comp := artifact.NewCompressorGzip()
+				cmd := exec.Command(filepath.Join(dir, "mender-artifact"), "cat", imgpath+":/etc/mender/testkey.key")
+				var out bytes.Buffer
+				cmd.Stdout = &out
+				err := cmd.Run()
+				assert.Nil(t, err, "got unexpected error: %v", err)
+				assert.Equal(t, "foobar", out.String())
+				// Cleanup the testkey
+				assert.Nil(t, os.Remove("testkey"))
+				// Check that the permission bits have been set correctly!
+				pf, err := virtualPartitionFile.Open(comp, imgpath+":/etc/mender/testkey.key")
+				defer pf.Close()
+				require.Nil(t, err)
+				// Type switch on the artifact, or sdimg underlying
+				switch pf.(type) {
+				case *artifactExtFile:
+					imgpath := pf.(*artifactExtFile).path
+					bin, err := utils.GetBinaryPath("debugfs")
+					require.Nil(t, err)
+					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
+					out, err := cmd.CombinedOutput()
+					require.Nil(t, err)
+					assert.True(t, strings.Contains(string(out), "Mode:  0777"))
+				case sdimgFile:
+					imgpath := pf.(sdimgFile)[0].(*extFile).path
+					bin, err := utils.GetBinaryPath("debugfs")
+					require.Nil(t, err)
+					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
+					out, err := cmd.CombinedOutput()
+					require.Nil(t, err)
+					assert.True(t, strings.Contains(string(out), "Mode:  0777"))
+				default:
+					t.Fatal("Unexpected file type")
+				}
+			},
+		},
+		{
+			name: "Install file with permissions (0700)",
+			initfunc: func(imgpath string) {
+				require.Nil(t, ioutil.WriteFile("testkey", []byte("foobar"), 0644))
+			},
+			argv: []string{"mender-artifact", "install", "-m", "0700", "testkey", "<artifact|sdimg|fat-sdimg>:/etc/mender/testkey.key"},
+			verifyTestFunc: func(imgpath string) {
+				comp := artifact.NewCompressorGzip()
+				cmd := exec.Command(filepath.Join(dir, "mender-artifact"), "cat", imgpath+":/etc/mender/testkey.key")
+				var out bytes.Buffer
+				cmd.Stdout = &out
+				err := cmd.Run()
+				assert.Nil(t, err, "got unexpected error: %v", err)
+				assert.Equal(t, "foobar", out.String())
+				// Cleanup the testkey
+				assert.Nil(t, os.Remove("testkey"))
+				// Check that the permission bits have been set correctly!
+				pf, err := virtualPartitionFile.Open(comp, imgpath+":/etc/mender/testkey.key")
+				defer pf.Close()
+				require.Nil(t, err)
+				// Type switch on the artifact, or sdimg underlying
+				switch pf.(type) {
+				case *artifactExtFile:
+					imgpath := pf.(*artifactExtFile).path
+					bin, err := utils.GetBinaryPath("debugfs")
+					require.Nil(t, err)
+					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
+					out, err := cmd.CombinedOutput()
+					require.Nil(t, err)
+					assert.True(t, strings.Contains(string(out), "Mode:  0700"))
+				case sdimgFile:
+					imgpath := pf.(sdimgFile)[0].(*extFile).path
+					bin, err := utils.GetBinaryPath("debugfs")
+					require.Nil(t, err)
+					cmd := exec.Command(bin, "-R", "stat /etc/mender/testkey.key", imgpath)
+					out, err := cmd.CombinedOutput()
+					require.Nil(t, err)
+					assert.True(t, strings.Contains(string(out), "Mode:  0700"))
+				default:
+					t.Fatal("Unexpected file type")
 				}
 			},
 		},


### PR DESCRIPTION
The current Mender-Artifact install functionality had a bug in which the
temp-files it creates and uses for moving a file from the host to the target
with debugfs were created with the standard file permissions (0600). This did
pass test as only (0600) was tested. This fix creates a new temp-file, and
explicitly sets the file-permissions on it to match the one given on the command
line.

It has also added a couple of more test cases (0777, 0700) to make sure that the
same error as seen before does not slip unnoticed through the tests.

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>