### PR TITLE
FIX: MergeArtifact[Depends|Provides] panic on empty depends/provides …

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -1041,6 +1041,10 @@ func (ar *Reader) MergeArtifactDepends() (map[string]interface{}, error) {
 	retMap := make(map[string]interface{})
 
 	depends := ar.GetArtifactDepends()
+	if depends == nil {
+		// Artifact version < 3
+		return nil, nil
+	}
 
 	retMap["artifact_name"] = depends.ArtifactName
 	retMap["compatible_devices"] = depends.CompatibleDevices
@@ -1052,6 +1056,8 @@ func (ar *Reader) MergeArtifactDepends() (map[string]interface{}, error) {
 		deps, err := upd.GetUpdateDepends()
 		if err != nil {
 			return nil, err
+		} else if deps == nil {
+			continue
 		}
 		for key, val := range deps.Map() {
 			// Ensure there are no matching keys
@@ -1070,6 +1076,10 @@ func (ar *Reader) MergeArtifactProvides() (map[string]interface{}, error) {
 	retMap := make(map[string]interface{})
 
 	provides := ar.GetArtifactProvides()
+	if provides == nil {
+		// Artifact version < 3
+		return nil, nil
+	}
 
 	retMap["artifact_name"] = provides.ArtifactName
 	retMap["artifact_group"] = provides.ArtifactGroup
@@ -1080,6 +1090,8 @@ func (ar *Reader) MergeArtifactProvides() (map[string]interface{}, error) {
 		p, err := upd.GetUpdateProvides()
 		if err != nil {
 			return nil, err
+		} else if p == nil {
+			continue
 		}
 		for key, val := range p.Map() {
 			// Ensure there are no matching keys

--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -1346,6 +1346,43 @@ func TestMergeDependsSuccess(t *testing.T) {
 				"foo":                "boo",
 			},
 		},
+		{
+			// No type-info depends
+			r: Reader{
+				hInfo: &artifact.HeaderInfoV3{
+					ArtifactDepends: &artifact.ArtifactDepends{
+						ArtifactName:      []string{"foo"},
+						CompatibleDevices: []string{"qemux86-64"},
+						ArtifactGroup:     []string{"ac-dc"},
+					},
+				},
+				installers: map[int]handlers.Installer{
+					1: &installer{
+						typeInfoV3: &artifact.TypeInfoV3{
+							ArtifactDepends: nil,
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"artifact_name":      []string{"foo"},
+				"compatible_devices": []string{"qemux86-64"},
+				"artifact_group":     []string{"ac-dc"},
+			},
+		},
+		{
+			// Artifact version 2
+			r: Reader{
+				hInfo: &artifact.HeaderInfo{
+					ArtifactName:      "foo",
+					CompatibleDevices: []string{"qemux86-64"},
+				},
+				installers: map[int]handlers.Installer{
+					1: &installer{},
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -1382,7 +1419,6 @@ func TestMergeDependsError(t *testing.T) {
 			},
 		},
 	}
-
 	for _, test := range tests {
 		_, err := test.r.MergeArtifactDepends()
 		assert.NotNil(t, err)
@@ -1420,6 +1456,41 @@ func TestMergeProvidesSuccess(t *testing.T) {
 				"bar":            "baz",
 				"foo":            "boo",
 			},
+		},
+		{
+			// Single update -- empty type-info
+			r: Reader{
+				hInfo: &artifact.HeaderInfoV3{
+					ArtifactProvides: &artifact.ArtifactProvides{
+						ArtifactName:  "foo",
+						ArtifactGroup: "ac-dc",
+					},
+				},
+				installers: map[int]handlers.Installer{
+					1: &installer{
+						typeInfoV3: &artifact.TypeInfoV3{
+							ArtifactProvides: nil,
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"artifact_name":  "foo",
+				"artifact_group": "ac-dc",
+			},
+		},
+		{
+			// Single update -- version 2 header
+			r: Reader{
+				hInfo: &artifact.HeaderInfo{
+					ArtifactName:      "foo",
+					CompatibleDevices: []string{"ac-dc"},
+				},
+				installers: map[int]handlers.Installer{
+					1: &installer{},
+				},
+			},
+			expected: nil,
 		},
 	}
 


### PR DESCRIPTION
…in type-info

changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>