### PR TITLE
MEN-2956: Write `rootfs_image_checksum` provides in rootfs-image

### DIFF
--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -162,6 +162,12 @@ func getCliContext() *cli.App {
 			Usage: "Full path to the state script(s). You can specify multiple " +
 				"scripts providing this parameter multiple times.",
 		},
+		cli.BoolFlag{
+			Name: "no-checksum-provide",
+			Usage: "Disable writing the provides checksum to the Artifact provides " +
+				"parameters. This is needed in case the targeted devices do not support " +
+				"provides and depends yet.",
+		},
 		/////////////////////////
 		// Version 3 specifics.//
 		/////////////////////////

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -343,7 +343,8 @@ func TestModifyRootfsSigned(t *testing.T) {
 Updates:
     0:
     Type:   rootfs-image
-    Provides: Nothing
+    Provides:
+	rootfs_image_checksum: dc66c40bc3e52e1d0d3f46f417cbb8e12a86bc63b2a9b3be91ee77aa0fd680b0
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -370,7 +371,8 @@ Updates:
 Updates:
     0:
     Type:   rootfs-image
-    Provides: Nothing
+    Provides:
+	rootfs_image_checksum: dc66c40bc3e52e1d0d3f46f417cbb8e12a86bc63b2a9b3be91ee77aa0fd680b0
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -424,7 +426,8 @@ Updates:
 Updates:
     0:
     Type:   rootfs-image
-    Provides: Nothing
+    Provides:
+	rootfs_image_checksum: dc66c40bc3e52e1d0d3f46f417cbb8e12a86bc63b2a9b3be91ee77aa0fd680b0
     Depends: Nothing
     Metadata: Nothing
     Files:

--- a/cli/mender-artifact/read_test.go
+++ b/cli/mender-artifact/read_test.go
@@ -175,7 +175,8 @@ Updates:
 Updates:
     0:
     Type:   rootfs-image
-    Provides: Nothing
+    Provides:
+	rootfs_image_checksum: ee7cd8c4f4613a5dd2bf585815a77209a13ea7410aa5dedcc8654993b30a4972
     Depends: Nothing
     Metadata: Nothing
     Files:


### PR DESCRIPTION
Previously the `write rootfs-image` command did not write the provided checksum
to the Artifact.

This commits makes sure the checksum is always provided when writing a
rootfs-image Artifact.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>