### PR TITLE
Change the type of artifact.TypeInfoDepends and Provides 

### DIFF
--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -418,14 +418,14 @@ func (i *installer) SetUpdateAugmentFiles(files [](*handlers.DataFile)) error {
 	return nil
 }
 
-func (i *installer) GetUpdateDepends() (*artifact.TypeInfoDepends, error) {
+func (i *installer) GetUpdateDepends() (artifact.TypeInfoDepends, error) {
 	// NOTE: For testing purposes, only typeInfoV3 is returned.
 	//Original functionality merges typeInfo, and the augmentedTypeInfo,
 	// So beware!
 	return i.typeInfoV3.ArtifactDepends, nil
 }
 
-func (i *installer) GetUpdateProvides() (*artifact.TypeInfoProvides, error) {
+func (i *installer) GetUpdateProvides() (artifact.TypeInfoProvides, error) {
 	// NOTE: For testing purposes, only typeInfoV3 is returned.
 	//Original functionality merges typeInfo, and the augmentedTypeInfo,
 	// So beware!
@@ -436,24 +436,24 @@ func (i *installer) GetUpdateMetaData() (map[string]interface{}, error) {
 	return nil, nil
 }
 
-func (i *installer) GetUpdateOriginalDepends() *artifact.TypeInfoDepends {
-	return &artifact.TypeInfoDepends{}
+func (i *installer) GetUpdateOriginalDepends() artifact.TypeInfoDepends {
+	return artifact.TypeInfoDepends{}
 }
 
-func (i *installer) GetUpdateOriginalProvides() *artifact.TypeInfoProvides {
-	return &artifact.TypeInfoProvides{}
+func (i *installer) GetUpdateOriginalProvides() artifact.TypeInfoProvides {
+	return artifact.TypeInfoProvides{}
 }
 
 func (i *installer) GetUpdateOriginalMetaData() map[string]interface{} {
 	return nil
 }
 
-func (i *installer) GetUpdateAugmentDepends() *artifact.TypeInfoDepends {
-	return &artifact.TypeInfoDepends{}
+func (i *installer) GetUpdateAugmentDepends() artifact.TypeInfoDepends {
+	return artifact.TypeInfoDepends{}
 }
 
-func (i *installer) GetUpdateAugmentProvides() *artifact.TypeInfoProvides {
-	return &artifact.TypeInfoProvides{}
+func (i *installer) GetUpdateAugmentProvides() artifact.TypeInfoProvides {
+	return artifact.TypeInfoProvides{}
 }
 
 func (i *installer) GetUpdateAugmentMetaData() map[string]interface{} {
@@ -1332,7 +1332,7 @@ func TestMergeDependsSuccess(t *testing.T) {
 				installers: map[int]handlers.Installer{
 					1: &installer{
 						typeInfoV3: &artifact.TypeInfoV3{
-							ArtifactDepends: &artifact.TypeInfoDepends{
+							ArtifactDepends: artifact.TypeInfoDepends{
 								"foo": "boo",
 							},
 						},
@@ -1410,7 +1410,7 @@ func TestMergeDependsError(t *testing.T) {
 				installers: map[int]handlers.Installer{
 					1: &installer{
 						typeInfoV3: &artifact.TypeInfoV3{
-							ArtifactDepends: &artifact.TypeInfoDepends{
+							ArtifactDepends: artifact.TypeInfoDepends{
 								"artifact_name": "boo",
 							},
 						},
@@ -1442,7 +1442,7 @@ func TestMergeProvidesSuccess(t *testing.T) {
 				installers: map[int]handlers.Installer{
 					1: &installer{
 						typeInfoV3: &artifact.TypeInfoV3{
-							ArtifactProvides: &artifact.TypeInfoProvides{
+							ArtifactProvides: artifact.TypeInfoProvides{
 								"bar": "baz",
 								"foo": "boo",
 							},
@@ -1517,7 +1517,7 @@ func TestMergeProvidesError(t *testing.T) {
 				installers: map[int]handlers.Installer{
 					1: &installer{
 						typeInfoV3: &artifact.TypeInfoV3{
-							ArtifactProvides: &artifact.TypeInfoProvides{
+							ArtifactProvides: artifact.TypeInfoProvides{
 								"artifact_name": 1,
 							},
 						},

--- a/artifact/metadata.go
+++ b/artifact/metadata.go
@@ -395,9 +395,9 @@ type TypeInfoV3 struct {
 	Type string `json:"type"`
 	// Checksum of the image that needs to be installed on the device in order to
 	// apply the current update.
-	ArtifactDepends *TypeInfoDepends `json:"artifact_depends,omitempty"`
+	ArtifactDepends TypeInfoDepends `json:"artifact_depends,omitempty"`
 	// Checksum of the image currently installed on the device.
-	ArtifactProvides *TypeInfoProvides `json:"artifact_provides,omitempty"`
+	ArtifactProvides TypeInfoProvides `json:"artifact_provides,omitempty"`
 }
 
 // Validate checks that the required `Type` field is set.

--- a/artifact/metadata_test.go
+++ b/artifact/metadata_test.go
@@ -335,10 +335,10 @@ func TestMarshalJSONTypeInfoV3(t *testing.T) {
 		"delta": {
 			ti: TypeInfoV3{
 				Type: "delta",
-				ArtifactDepends: &TypeInfoDepends{
+				ArtifactDepends: TypeInfoDepends{
 					"rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619",
 				},
-				ArtifactProvides: &TypeInfoProvides{
+				ArtifactProvides: TypeInfoProvides{
 					"rootfs_image_checksum": "853jsdfh342789sdflkjsdf987324kljsdf987234kjljsdf987234klsdf987d8",
 				},
 			},

--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -254,8 +254,8 @@ func reconstructPayloadWriteData(info *artifact.Info, inst map[int]handlers.Inst
 			return
 		}
 
-		var uDepends *artifact.TypeInfoDepends
-		var uProvides *artifact.TypeInfoProvides
+		var uDepends artifact.TypeInfoDepends
+		var uProvides artifact.TypeInfoProvides
 
 		if uDepends, err = inst[0].GetUpdateDepends(); err != nil {
 			return

--- a/cli/mender-artifact/artifacts_test.go
+++ b/cli/mender-artifact/artifacts_test.go
@@ -165,8 +165,8 @@ func WriteArtifact(dir string, ver int, update string) error {
 		// later, when we add support for augmented artifacts.
 		// ArtifactDepends:  &artifact.TypeInfoDepends{"rootfs_image_checksum": c.String("depends-rootfs-image-checksum")},
 		// ArtifactProvides: &artifact.TypeInfoProvides{"rootfs_image_checksum": c.String("provides-rootfs-image-checksum")},
-		ArtifactDepends:  &artifact.TypeInfoDepends{},
-		ArtifactProvides: &artifact.TypeInfoProvides{},
+		ArtifactDepends:  artifact.TypeInfoDepends{},
+		ArtifactProvides: artifact.TypeInfoProvides{},
 	}
 
 	return aw.WriteArtifact(&awriter.WriteArtifactArgs{

--- a/cli/mender-artifact/dump.go
+++ b/cli/mender-artifact/dump.go
@@ -205,14 +205,14 @@ func printCmdline(ar *areader.Reader, args []string) {
 
 	provs := handler.GetUpdateOriginalProvides()
 	if provs != nil {
-		for key, value := range *provs {
+		for key, value := range provs {
 			fmt.Printf(" --provides %s:%s", key, value)
 		}
 	}
 
 	deps := handler.GetUpdateOriginalDepends()
 	if deps != nil {
-		for key, value := range *deps {
+		for key, value := range deps {
 			fmt.Printf(" --depends %s:%s", key, value)
 		}
 	}

--- a/cli/mender-artifact/modify.go
+++ b/cli/mender-artifact/modify.go
@@ -263,7 +263,7 @@ func modifyPayloadAttributes(c *cli.Context, image VPImage) error {
 		}
 		// The unconditional cast usage here is safe due to the
 		// `extractKeyValuesIfArtifact` call above.
-		art.writeArgs.TypeInfoV3.ArtifactDepends = &typeInfoDepends
+		art.writeArgs.TypeInfoV3.ArtifactDepends = typeInfoDepends
 	}
 
 	keyValues, err = extractKeyValuesIfArtifact(c, "provides", image)
@@ -274,7 +274,7 @@ func modifyPayloadAttributes(c *cli.Context, image VPImage) error {
 		if err != nil {
 			return err
 		}
-		art.writeArgs.TypeInfoV3.ArtifactProvides = &typeInfoProvides
+		art.writeArgs.TypeInfoV3.ArtifactProvides = typeInfoProvides
 	}
 
 	keyValues, err = extractKeyValuesIfArtifact(c, "augment-depends", image)
@@ -285,7 +285,7 @@ func modifyPayloadAttributes(c *cli.Context, image VPImage) error {
 		if err != nil {
 			return err
 		}
-		art.writeArgs.AugmentTypeInfoV3.ArtifactDepends = &typeInfoDepends
+		art.writeArgs.AugmentTypeInfoV3.ArtifactDepends = typeInfoDepends
 	}
 
 	keyValues, err = extractKeyValuesIfArtifact(c, "augment-provides", image)
@@ -296,7 +296,7 @@ func modifyPayloadAttributes(c *cli.Context, image VPImage) error {
 		if err != nil {
 			return err
 		}
-		art.writeArgs.AugmentTypeInfoV3.ArtifactProvides = &typeInfoProvides
+		art.writeArgs.AugmentTypeInfoV3.ArtifactProvides = typeInfoProvides
 	}
 
 	metaData, augMetaData, err := makeMetaData(c)

--- a/cli/mender-artifact/read.go
+++ b/cli/mender-artifact/read.go
@@ -133,14 +133,14 @@ func printPayload(index int, p handlers.Installer) {
 	fmt.Printf("    Provides:")
 	if err != nil {
 		fmt.Printf(" Invalid provides section: %s\n", err.Error())
-	} else if provides == nil || len(*provides) == 0 {
+	} else if provides == nil || len(provides) == 0 {
 		fmt.Printf(" Nothing\n")
 	} else {
-		providesKeys := sortedKeys(*provides)
+		providesKeys := sortedKeys(provides)
 
 		fmt.Printf("\n")
 		for _, provideKey := range providesKeys {
-			fmt.Printf("\t%s: %s\n", provideKey, (*provides)[provideKey])
+			fmt.Printf("\t%s: %s\n", provideKey, (provides)[provideKey])
 		}
 	}
 
@@ -148,14 +148,14 @@ func printPayload(index int, p handlers.Installer) {
 	fmt.Printf("    Depends:")
 	if err != nil {
 		fmt.Printf(" Invalid depends section: %s\n", err.Error())
-	} else if depends == nil || len(*depends) == 0 {
+	} else if depends == nil || len(depends) == 0 {
 		fmt.Printf(" Nothing\n")
 	} else {
-		dependsKeys := sortedKeys(*depends)
+		dependsKeys := sortedKeys(depends)
 
 		fmt.Printf("\n")
 		for _, dependKey := range dependsKeys {
-			fmt.Printf("\t%s: %s\n", dependKey, (*depends)[dependKey])
+			fmt.Printf("\t%s: %s\n", dependKey, (depends)[dependKey])
 		}
 	}
 

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -251,8 +251,8 @@ func makeTypeInfo(ctx *cli.Context) (*artifact.TypeInfoV3, *artifact.TypeInfoV3,
 
 	typeInfoV3 := &artifact.TypeInfoV3{
 		Type:             ctx.String("type"),
-		ArtifactDepends:  &typeInfoDepends,
-		ArtifactProvides: &typeInfoProvides,
+		ArtifactDepends:  typeInfoDepends,
+		ArtifactProvides: typeInfoProvides,
 	}
 
 	if ctx.String("augment-type") == "" {
@@ -271,8 +271,8 @@ func makeTypeInfo(ctx *cli.Context) (*artifact.TypeInfoV3, *artifact.TypeInfoV3,
 
 	augmentTypeInfoV3 := &artifact.TypeInfoV3{
 		Type:             ctx.String("augment-type"),
-		ArtifactDepends:  &augmentTypeInfoDepends,
-		ArtifactProvides: &augmentTypeInfoProvides,
+		ArtifactDepends:  augmentTypeInfoDepends,
+		ArtifactProvides: augmentTypeInfoProvides,
 	}
 
 	return typeInfoV3, augmentTypeInfoV3, nil

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -256,13 +256,13 @@ func TestWriteModuleImage(t *testing.T) {
 		"testDependKey1":    "testDependValue1",
 		"testDependKey2":    "testDependValue2",
 		"overrideDependKey": "originalOverrideDependValue",
-	}, *updDepends)
+	}, updDepends)
 	updDepends = handler.GetUpdateAugmentDepends()
 	assert.Equal(t, artifact.TypeInfoDepends{
 		"augmentDependKey1": "augmentDependValue1",
 		"augmentDependKey2": "augmentDependValue2",
 		"overrideDependKey": "augmentOverrideDependValue",
-	}, *updDepends)
+	}, updDepends)
 	updDepends, err = handler.GetUpdateDepends()
 	require.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoDepends{
@@ -271,20 +271,20 @@ func TestWriteModuleImage(t *testing.T) {
 		"augmentDependKey1": "augmentDependValue1",
 		"augmentDependKey2": "augmentDependValue2",
 		"overrideDependKey": "augmentOverrideDependValue",
-	}, *updDepends)
+	}, updDepends)
 
 	updProvides := handler.GetUpdateOriginalProvides()
 	assert.Equal(t, artifact.TypeInfoProvides{
 		"testProvideKey1":    "testProvideValue1",
 		"testProvideKey2":    "testProvideValue2",
 		"overrideProvideKey": "originalOverrideProvideValue",
-	}, *updProvides)
+	}, updProvides)
 	updProvides = handler.GetUpdateAugmentProvides()
 	assert.Equal(t, artifact.TypeInfoProvides{
 		"augmentProvideKey1": "augmentProvideValue1",
 		"augmentProvideKey2": "augmentProvideValue2",
 		"overrideProvideKey": "augmentOverrideProvideValue",
-	}, *updProvides)
+	}, updProvides)
 	updProvides, err = handler.GetUpdateProvides()
 	require.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoProvides{
@@ -293,7 +293,7 @@ func TestWriteModuleImage(t *testing.T) {
 		"augmentProvideKey1": "augmentProvideValue1",
 		"augmentProvideKey2": "augmentProvideValue2",
 		"overrideProvideKey": "augmentOverrideProvideValue",
-	}, *updProvides)
+	}, updProvides)
 
 	assert.Equal(t, map[string]interface{}{"metadata": "test"}, handler.GetUpdateOriginalMetaData())
 	assert.Equal(t, map[string]interface{}{"metadata": "augment"}, handler.GetUpdateAugmentMetaData())
@@ -388,7 +388,7 @@ func TestWriteRootfsArtifactDependsAndProvides(t *testing.T) {
 	assert.Equal(t, artifact.TypeInfoDepends{
 		"testDependKey1": "testDependValue1",
 		"testDependKey2": "testDependValue2",
-	}, *updDepends)
+	}, updDepends)
 
 	// Type-Info Provides
 	updProvides, err := handler.GetUpdateProvides()
@@ -396,6 +396,6 @@ func TestWriteRootfsArtifactDependsAndProvides(t *testing.T) {
 	assert.Equal(t, artifact.TypeInfoProvides{
 		"testProvideKey1": "testProvideValue1",
 		"testProvideKey2": "testProvideValue2",
-	}, *updProvides)
+	}, updProvides)
 
 }

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -61,18 +61,18 @@ type ArtifactUpdateHeaders interface {
 
 	// Returns merged data of non-augmented and augmented data, where the
 	// latter overrides the former. Returns error if they cannot be merged.
-	GetUpdateDepends() (*artifact.TypeInfoDepends, error)
-	GetUpdateProvides() (*artifact.TypeInfoProvides, error)
+	GetUpdateDepends() (artifact.TypeInfoDepends, error)
+	GetUpdateProvides() (artifact.TypeInfoProvides, error)
 	GetUpdateMetaData() (map[string]interface{}, error) // Generic JSON
 
 	// Returns non-augmented (original) data.
-	GetUpdateOriginalDepends() *artifact.TypeInfoDepends
-	GetUpdateOriginalProvides() *artifact.TypeInfoProvides
+	GetUpdateOriginalDepends() artifact.TypeInfoDepends
+	GetUpdateOriginalProvides() artifact.TypeInfoProvides
 	GetUpdateOriginalMetaData() map[string]interface{} // Generic JSON
 
 	// Returns augmented data.
-	GetUpdateAugmentDepends() *artifact.TypeInfoDepends
-	GetUpdateAugmentProvides() *artifact.TypeInfoProvides
+	GetUpdateAugmentDepends() artifact.TypeInfoDepends
+	GetUpdateAugmentProvides() artifact.TypeInfoProvides
 	GetUpdateAugmentMetaData() map[string]interface{} // Generic JSON
 
 	GetUpdateOriginalTypeInfoWriter() io.Writer

--- a/handlers/module_image.go
+++ b/handlers/module_image.go
@@ -134,7 +134,7 @@ func (img *ModuleImage) GetUpdateAllFiles() [](*DataFile) {
 	return allFiles
 }
 
-func (img *ModuleImage) GetUpdateOriginalDepends() *artifact.TypeInfoDepends {
+func (img *ModuleImage) GetUpdateOriginalDepends() artifact.TypeInfoDepends {
 	if img.original == nil {
 		return img.typeInfoV3.ArtifactDepends
 	} else {
@@ -142,7 +142,7 @@ func (img *ModuleImage) GetUpdateOriginalDepends() *artifact.TypeInfoDepends {
 	}
 }
 
-func (img *ModuleImage) GetUpdateOriginalProvides() *artifact.TypeInfoProvides {
+func (img *ModuleImage) GetUpdateOriginalProvides() artifact.TypeInfoProvides {
 	if img.original == nil {
 		return img.typeInfoV3.ArtifactProvides
 	} else {
@@ -167,19 +167,19 @@ func (img *ModuleImage) setUpdateOriginalMetaData(metaData map[string]interface{
 	}
 }
 
-func (img *ModuleImage) GetUpdateAugmentDepends() *artifact.TypeInfoDepends {
+func (img *ModuleImage) GetUpdateAugmentDepends() artifact.TypeInfoDepends {
 	if img.original == nil {
 		ret := make(artifact.TypeInfoDepends)
-		return &ret
+		return ret
 	} else {
 		return img.typeInfoV3.ArtifactDepends
 	}
 }
 
-func (img *ModuleImage) GetUpdateAugmentProvides() *artifact.TypeInfoProvides {
+func (img *ModuleImage) GetUpdateAugmentProvides() artifact.TypeInfoProvides {
 	if img.original == nil {
 		ret := make(artifact.TypeInfoProvides)
-		return &ret
+		return ret
 	} else {
 		return img.typeInfoV3.ArtifactProvides
 	}
@@ -326,7 +326,7 @@ func transformGenericMapToStruct(src map[string]interface{}, dst interface{}) er
 	return nil
 }
 
-func (img *ModuleImage) GetUpdateDepends() (*artifact.TypeInfoDepends, error) {
+func (img *ModuleImage) GetUpdateDepends() (artifact.TypeInfoDepends, error) {
 	orig, err := transformStructToGenericMap(img.GetUpdateOriginalDepends())
 	if err != nil {
 		return nil, err
@@ -347,10 +347,10 @@ func (img *ModuleImage) GetUpdateDepends() (*artifact.TypeInfoDepends, error) {
 		return nil, err
 	}
 
-	return &depends, nil
+	return merged, nil
 }
 
-func (img *ModuleImage) GetUpdateProvides() (*artifact.TypeInfoProvides, error) {
+func (img *ModuleImage) GetUpdateProvides() (artifact.TypeInfoProvides, error) {
 	orig, err := transformStructToGenericMap(img.GetUpdateOriginalProvides())
 	if err != nil {
 		return nil, err
@@ -371,7 +371,7 @@ func (img *ModuleImage) GetUpdateProvides() (*artifact.TypeInfoProvides, error) 
 		return nil, err
 	}
 
-	return &provides, nil
+	return provides, nil
 }
 
 func (img *ModuleImage) GetUpdateMetaData() (map[string]interface{}, error) {

--- a/handlers/module_image_test.go
+++ b/handlers/module_image_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -159,10 +159,10 @@ func TestModuleImageGetProperties(t *testing.T) {
 	augm := NewAugmentedModuleImage(orig, "test-type")
 
 	orig.typeInfoV3 = &artifact.TypeInfoV3{}
-	orig.typeInfoV3.ArtifactDepends = &artifact.TypeInfoDepends{
+	orig.typeInfoV3.ArtifactDepends = artifact.TypeInfoDepends{
 		"testDependKey": "testDependValue",
 	}
-	orig.typeInfoV3.ArtifactProvides = &artifact.TypeInfoProvides{
+	orig.typeInfoV3.ArtifactProvides = artifact.TypeInfoProvides{
 		"testProvideKey": "testProvideValue",
 	}
 	orig.metaData = map[string]interface{}{
@@ -170,10 +170,10 @@ func TestModuleImageGetProperties(t *testing.T) {
 	}
 
 	augm.typeInfoV3 = &artifact.TypeInfoV3{}
-	augm.typeInfoV3.ArtifactDepends = &artifact.TypeInfoDepends{
+	augm.typeInfoV3.ArtifactDepends = artifact.TypeInfoDepends{
 		"testAugmentDependKey": "testAugmentDependValue",
 	}
-	augm.typeInfoV3.ArtifactProvides = &artifact.TypeInfoProvides{
+	augm.typeInfoV3.ArtifactProvides = artifact.TypeInfoProvides{
 		"testAugmentProvideKey": "testAugmentProvideValue",
 	}
 	augm.metaData = map[string]interface{}{
@@ -184,13 +184,13 @@ func TestModuleImageGetProperties(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoDepends{
 		"testDependKey": "testDependValue",
-	}, *depends)
+	}, depends)
 
 	provides, err := orig.GetUpdateProvides()
 	assert.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoProvides{
 		"testProvideKey": "testProvideValue",
-	}, *provides)
+	}, provides)
 
 	metaData, err := orig.GetUpdateMetaData()
 	assert.NoError(t, err)
@@ -203,14 +203,14 @@ func TestModuleImageGetProperties(t *testing.T) {
 	assert.Equal(t, artifact.TypeInfoDepends{
 		"testDependKey":        "testDependValue",
 		"testAugmentDependKey": "testAugmentDependValue",
-	}, *depends)
+	}, depends)
 
 	provides, err = augm.GetUpdateProvides()
 	assert.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoProvides{
 		"testProvideKey":        "testProvideValue",
 		"testAugmentProvideKey": "testAugmentProvideValue",
-	}, *provides)
+	}, provides)
 
 	metaData, err = augm.GetUpdateMetaData()
 	assert.NoError(t, err)
@@ -219,8 +219,8 @@ func TestModuleImageGetProperties(t *testing.T) {
 		"testAugmentMetaDataKey": "testAugmentMetaDataValue",
 	}, metaData)
 
-	(*augm.typeInfoV3.ArtifactDepends)["testDependKey"] = "alternateValue"
-	(*augm.typeInfoV3.ArtifactProvides)["testProvideKey"] = "alternateValue"
+	(augm.typeInfoV3.ArtifactDepends)["testDependKey"] = "alternateValue"
+	(augm.typeInfoV3.ArtifactProvides)["testProvideKey"] = "alternateValue"
 	augm.metaData["testMetaDataKey"] = "alternateValue"
 
 	depends, err = augm.GetUpdateDepends()
@@ -228,14 +228,14 @@ func TestModuleImageGetProperties(t *testing.T) {
 	assert.Equal(t, artifact.TypeInfoDepends{
 		"testDependKey":        "alternateValue",
 		"testAugmentDependKey": "testAugmentDependValue",
-	}, *depends)
+	}, depends)
 
 	provides, err = augm.GetUpdateProvides()
 	assert.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoProvides{
 		"testProvideKey":        "alternateValue",
 		"testAugmentProvideKey": "testAugmentProvideValue",
-	}, *provides)
+	}, provides)
 
 	metaData, err = augm.GetUpdateMetaData()
 	assert.NoError(t, err)

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -244,11 +244,11 @@ func (rfs *Rootfs) GetUpdateOriginalType() string {
 	return ""
 }
 
-func (rfs *Rootfs) GetUpdateDepends() (*artifact.TypeInfoDepends, error) {
+func (rfs *Rootfs) GetUpdateDepends() (artifact.TypeInfoDepends, error) {
 	return rfs.GetUpdateOriginalDepends(), nil
 }
 
-func (rfs *Rootfs) GetUpdateProvides() (*artifact.TypeInfoProvides, error) {
+func (rfs *Rootfs) GetUpdateProvides() (artifact.TypeInfoProvides, error) {
 	return rfs.GetUpdateOriginalProvides(), nil
 }
 
@@ -274,14 +274,14 @@ func (rfs *Rootfs) setUpdateAugmentMetaData(jsonObj map[string]interface{}) erro
 	return nil
 }
 
-func (rfs *Rootfs) GetUpdateOriginalDepends() *artifact.TypeInfoDepends {
+func (rfs *Rootfs) GetUpdateOriginalDepends() artifact.TypeInfoDepends {
 	if rfs.typeInfoV3 == nil {
 		return nil
 	}
 	return rfs.typeInfoV3.ArtifactDepends
 }
 
-func (rfs *Rootfs) GetUpdateOriginalProvides() *artifact.TypeInfoProvides {
+func (rfs *Rootfs) GetUpdateOriginalProvides() artifact.TypeInfoProvides {
 	if rfs.typeInfoV3 == nil {
 		return nil
 	}
@@ -296,11 +296,11 @@ func (rfs *Rootfs) GetUpdateOriginalMetaData() map[string]interface{} {
 	}
 }
 
-func (rfs *Rootfs) GetUpdateAugmentDepends() *artifact.TypeInfoDepends {
+func (rfs *Rootfs) GetUpdateAugmentDepends() artifact.TypeInfoDepends {
 	return nil
 }
 
-func (rfs *Rootfs) GetUpdateAugmentProvides() *artifact.TypeInfoProvides {
+func (rfs *Rootfs) GetUpdateAugmentProvides() artifact.TypeInfoProvides {
 	return nil
 }
 

--- a/handlers/rootfs_image_test.go
+++ b/handlers/rootfs_image_test.go
@@ -177,7 +177,7 @@ func TestComposeHeader(t *testing.T) {
 			rfs: NewAugmentedRootfs(NewRootfsV3(""), ""),
 			args: ComposeHeaderArgs{
 				TarWriter:  tar.NewWriter(bytes.NewBuffer(nil)),
-				TypeInfoV3: &artifact.TypeInfoV3{ArtifactProvides: &artifact.TypeInfoProvides{}},
+				TypeInfoV3: &artifact.TypeInfoV3{ArtifactProvides: artifact.TypeInfoProvides{}},
 				Augmented:  true,
 			},
 			verifyFunc: func(args ComposeHeaderArgs) { assert.Nil(t, args.TypeInfoV3) },


### PR DESCRIPTION
Previously artifact.TypeInfoDepends was of type pointer to map.

This commit removes the pointer, as every map in go is imiplicitly a pointer to
a map, and hence the extra pointer is unnecessary, and in fact has caused a lot
of fugly code in order to mitigate this poor design choice.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>