### PR TITLE
Accept suffix '.img' for mender-artifact modifiable images

### DIFF
--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var isimg = regexp.MustCompile(`\.(mender|sdimg|uefiimg)`)
+var isimg = regexp.MustCompile(`\.(mender|sdimg|uefiimg|img)`)
 
 func Cat(c *cli.Context) (err error) {
 	comp, err := artifact.NewCompressorFromId(c.GlobalString("compression"))


### PR DESCRIPTION
Previously we were allowing only Yocto naming convention sdimg, uefiimg,
but it might come in handy to modify a .img image (i.e. converted
Raspbian).