### PR TITLE
FIX: MergeArtifact[Depends|Provides] obeys json tags

### DIFF
--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -1340,10 +1340,10 @@ func TestMergeDependsSuccess(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"artifact_name":      []string{"foo"},
-				"compatible_devices": []string{"qemux86-64"},
-				"artifact_group":     []string{"ac-dc"},
-				"foo":                "boo",
+				"artifact_name":  []interface{}{"foo"},
+				"device_type":    []interface{}{"qemux86-64"},
+				"artifact_group": []interface{}{"ac-dc"},
+				"foo":            "boo",
 			},
 		},
 		{
@@ -1365,9 +1365,9 @@ func TestMergeDependsSuccess(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"artifact_name":      []string{"foo"},
-				"compatible_devices": []string{"qemux86-64"},
-				"artifact_group":     []string{"ac-dc"},
+				"artifact_name":  []interface{}{"foo"},
+				"device_type":    []interface{}{"qemux86-64"},
+				"artifact_group": []interface{}{"ac-dc"},
 			},
 		},
 		{
@@ -1388,7 +1388,7 @@ func TestMergeDependsSuccess(t *testing.T) {
 	for _, test := range tests {
 		d, err := test.r.MergeArtifactDepends()
 		assert.Nil(t, err)
-		assert.Equal(t, d, test.expected)
+		assert.Equal(t, test.expected, d)
 	}
 }
 
@@ -1497,7 +1497,7 @@ func TestMergeProvidesSuccess(t *testing.T) {
 	for _, test := range tests {
 		d, err := test.r.MergeArtifactProvides()
 		assert.Nil(t, err)
-		assert.Equal(t, d, test.expected)
+		assert.EqualValues(t, d, test.expected)
 	}
 }
 

--- a/artifact/metadata.go
+++ b/artifact/metadata.go
@@ -296,17 +296,38 @@ func (t TypeInfoDepends) Map() map[string]interface{} {
 }
 
 func NewTypeInfoDepends(m interface{}) (ti TypeInfoDepends, err error) {
+
+	const errMsgInvalidTypeFmt = "Invalid TypeInfo depends type: %T"
+	const errMsgInvalidTypeEntFmt = errMsgInvalidTypeFmt + ", with value %v"
+
 	ti = make(map[string]interface{})
 	switch m.(type) {
 	case map[string]interface{}:
 		m := m.(map[string]interface{})
 		for k, v := range m {
 			switch v.(type) {
+
 			case string, []string:
 				ti[k] = v
-				continue
+
+			case []interface{}:
+				valFace := v.([]interface{})
+				valStr := make([]string, len(valFace))
+				for i, entFace := range v.([]interface{}) {
+					entStr, ok := entFace.(string)
+					if !ok {
+						return nil, fmt.Errorf(
+							errMsgInvalidTypeEntFmt,
+							v, v)
+					}
+					valStr[i] = entStr
+				}
+				ti[k] = valStr
+
 			default:
-				return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+				return nil, fmt.Errorf(
+					errMsgInvalidTypeEntFmt,
+					v, v)
 			}
 		}
 		return ti, nil
@@ -323,7 +344,7 @@ func NewTypeInfoDepends(m interface{}) (ti TypeInfoDepends, err error) {
 		}
 		return ti, nil
 	default:
-		return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+		return nil, fmt.Errorf(errMsgInvalidTypeFmt, m)
 	}
 }
 
@@ -346,17 +367,36 @@ func (t TypeInfoProvides) Map() map[string]interface{} {
 }
 
 func NewTypeInfoProvides(m interface{}) (ti TypeInfoProvides, err error) {
+
+	const errMsgInvalidTypeFmt = "Invalid TypeInfo provides type: %T"
+	const errMsgInvalidTypeEntFmt = errMsgInvalidTypeFmt + ", with value %v"
+
 	ti = make(map[string]interface{})
 	switch m.(type) {
 	case map[string]interface{}:
 		m := m.(map[string]interface{})
 		for k, v := range m {
 			switch v.(type) {
+			case []interface{}:
+				valFace := v.([]interface{})
+				valStr := make([]string, len(valFace))
+				for i, entFace := range v.([]interface{}) {
+					entStr, ok := entFace.(string)
+					if !ok {
+						return nil, fmt.Errorf(
+							errMsgInvalidTypeEntFmt,
+							v, v)
+					}
+					valStr[i] = entStr
+				}
+				ti[k] = valStr
+
 			case string, []string:
 				ti[k] = v
 				continue
 			default:
-				return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+				return nil, fmt.Errorf(errMsgInvalidTypeEntFmt,
+					v, v)
 			}
 		}
 		return ti, nil
@@ -373,7 +413,7 @@ func NewTypeInfoProvides(m interface{}) (ti TypeInfoProvides, err error) {
 		}
 		return ti, nil
 	default:
-		return nil, fmt.Errorf("Invalid TypeInfo type: %T", m)
+		return nil, fmt.Errorf(errMsgInvalidTypeFmt, m)
 	}
 }
 

--- a/artifact/metadata.go
+++ b/artifact/metadata.go
@@ -56,6 +56,7 @@ func decode(p []byte, data WriteValidator) error {
 	}
 
 	dec := json.NewDecoder(bytes.NewReader(p))
+	dec.DisallowUnknownFields()
 	err := dec.Decode(data)
 	if err != nil {
 		return err

--- a/artifact/metadata_test.go
+++ b/artifact/metadata_test.go
@@ -449,6 +449,16 @@ func TestNewTypeInfoSuccess(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name: "Valid: json-encoded map[string]interface{}",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"bar": []interface{}{
+					"boo", "baz",
+				},
+			},
+			err: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/utils/json.go
+++ b/utils/json.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import "encoding/json"
+
+func AppendStructToMap(Struct interface{}, Map map[string]interface{}) error {
+	buf, err := json.Marshal(Struct)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(buf, &Map); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MarshallStructToMap(Struct interface{}) (map[string]interface{}, error) {
+	retMap := make(map[string]interface{})
+	if err := AppendStructToMap(Struct, retMap); err != nil {
+		return nil, err
+	}
+	return retMap, nil
+}

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -1,0 +1,83 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendStructToMap(t *testing.T) {
+	testMap := make(map[string]interface{})
+	testStruct := struct {
+		V1 string
+		V2 int
+		V3 map[string]interface{}
+		V4 map[int]chan interface{} `,omitempty`
+	}{
+		V1: "test",
+		V2: 123,
+		V3: map[string]interface{}{
+			"foo": "bar",
+			"baz": 123.0,
+		},
+	}
+
+	// Successfull test
+	err := AppendStructToMap(testStruct, testMap)
+	assert.NoError(t, err)
+	assert.Equal(t, "test", testMap["V1"])
+	assert.Equal(t, 123.0, testMap["V2"])
+	assert.Equal(t, testStruct.V3, testMap["V3"].(map[string]interface{}))
+	assert.Nil(t, testMap["V4"])
+
+	// Conflicting arguments
+	err = AppendStructToMap("foo", testMap)
+	assert.Error(t, err)
+
+	// Illegal struct argument
+	illegalStruct := struct {
+		FuncField func() string
+	}{
+		FuncField: func() string { return "You can't Marshal me!" },
+	}
+	err = AppendStructToMap(illegalStruct, testMap)
+	assert.Error(t, err)
+}
+
+func TestStructToMap(t *testing.T) {
+	testStruct := struct {
+		Foo string
+		Bar []string
+	}{
+		Foo: "føø",
+		Bar: []string{"bær", "båz"},
+	}
+
+	retMap, err := MarshallStructToMap(testStruct)
+	assert.NoError(t, err)
+	assert.Equal(t, "føø", retMap["Foo"])
+	assert.Equal(t, []interface{}{"bær", "båz"}, retMap["Bar"])
+
+	illegalStruct := struct {
+		Chan chan struct{}
+	}{
+		Chan: make(chan struct{}),
+	}
+
+	retMap, err = MarshallStructToMap(illegalStruct)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
In the current state, the MergeArtifactDepends/Provides forces a value to unset struct values which conflicts with the json tags which has side-effects when attempting to match dependencies with provides.