### PR TITLE
[pipeline] Set docker:dind image to a fixed version - 3.3.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
    S3_BUCKET_PATH: "mender-artifact"
 
 services:
-  - docker:dind
+  - docker:19.03.5-dind
 
 stages:
   - test


### PR DESCRIPTION
Cherry picking c48a4ca into 3.3.x