### PR TITLE
Bugfix (cli/snapshot): signal-loop on ignored signals

### DIFF
--- a/cli/mender-artifact/util/tty_windows.go
+++ b/cli/mender-artifact/util/tty_windows.go
@@ -49,7 +49,7 @@ func DisableEcho(fd int) (uint32, error) {
 // handles ^C or ^BREAK events to the terminal, thus the signal won't be
 // relayed to the OS handler for this case.
 func EchoSigHandler(sigChan chan os.Signal, errChan chan error,
-	cmode uint32, tmpFile string) {
+	cmode uint32) {
 	sig, sigRecved := <-sigChan
 	// Enable console echo (restore cmode)
 	windows.SetConsoleMode(windows.Handle(int(os.Stdin.Fd())), cmode)
@@ -57,7 +57,6 @@ func EchoSigHandler(sigChan chan os.Signal, errChan chan error,
 		signal.Stop(sigChan)
 		errChan <- errors.Errorf("Received signal: %s",
 			sig.String())
-		os.Remove(tmpFile)
 	} else {
 		errChan <- nil
 	}


### PR DESCRIPTION
If the forked ssh process received a signal which is ignored by default,
the signal is re-invoked using unix.Kill. This inevitably lead to an
invalid syscall instruction in case of SIGCHLD.

This commit makes SIGCHLD trigger terminal echo to be restored and
exits with an error. SIGURG and SIGWINCH are the only ignored signals.