### PR TITLE
Add ability for artifact install to create directories

### DIFF
--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -171,7 +171,7 @@ func Install(c *cli.Context) (err error) {
 			vdir, err := virtualImage.OpenDir(comp, privateKey, c.Args().First())
 			defer wclose(vdir)
 			if err != nil {
-				return cli.NewExitError(fmt.Sprintf("%v", err), 1)
+				return cli.NewExitError(err, 1)
 			}
 
 			if err = vdir.Create(); err != nil {

--- a/cli/mender-artifact/copy.go
+++ b/cli/mender-artifact/copy.go
@@ -137,7 +137,7 @@ func Copy(c *cli.Context) (err error) {
 	return nil
 }
 
-// Install installs a file from the host filesystem onto either
+// Install installs a file from the host filesystem or directory onto either
 // a mender artifact, or an sdimg.
 func Install(c *cli.Context) (err error) {
 	comp, err := artifact.NewCompressorFromId(c.GlobalString("compression"))
@@ -161,11 +161,24 @@ func Install(c *cli.Context) (err error) {
 	}
 	switch parseCLIOptions(c) {
 	case copyin:
+		directory := c.Bool("directory")
 		var perm os.FileMode
-		if c.Int("mode") == 0 {
+		if c.Int("mode") == 0 && !directory {
 			return cli.NewExitError("File permissions needs to be set, if you are simply copying, the cp command should fit your needs", 1)
 		}
 		perm = os.FileMode(c.Int("mode"))
+		if directory {
+			vdir, err := virtualImage.OpenDir(comp, privateKey, c.Args().First())
+			defer wclose(vdir)
+			if err != nil {
+				return cli.NewExitError(fmt.Sprintf("%v", err), 1)
+			}
+
+			if err = vdir.Create(); err != nil {
+				return cli.NewExitError(err, 1)
+			}
+			return nil
+		}
 		f, err := os.Open(c.Args().First())
 		defer f.Close()
 		if err != nil {
@@ -198,7 +211,7 @@ func Install(c *cli.Context) (err error) {
 	case parseError:
 		return cli.NewExitError("No artifact or sdimg provided", 1)
 	case argerror:
-		return cli.NewExitError(fmt.Sprintf("got %d arguments, wants two", c.NArg()), 1)
+		return cli.NewExitError(fmt.Sprintf("Wrong number of arguments, got %d", c.NArg()), 1)
 	default:
 		return cli.NewExitError("Unrecognized parse error", 1)
 	}
@@ -249,6 +262,17 @@ const (
 )
 
 func parseCLIOptions(c *cli.Context) int {
+
+	// If the -d flag is passed, parse for installing a directory
+	if c.Bool("directory") {
+		if c.NArg() != 1 {
+			return argerror
+		}
+		if !isimg.MatchString(c.Args().First()) {
+			return parseError
+		}
+		return copyin
+	}
 
 	if c.NArg() != 2 {
 		return argerror

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -699,6 +699,10 @@ func TestCopyRootfsImage(t *testing.T) {
 				assert.Nil(t, os.Remove("test.txt"))
 			},
 		},
+		{
+			name: "Create a directory that already exists",
+			argv: []string{"mender-artifact", "install", "-d", "<artifact|sdimg|fat-sdimg>:/"},
+		},
 	}
 
 	for _, test := range tests {

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -660,7 +660,7 @@ func TestCopyRootfsImage(t *testing.T) {
 			},
 		},
 		{
-			name: "Install a directory",
+			name: "Create a directory",
 			initfunc: func(imgpath string) {
 				require.Nil(t, ioutil.WriteFile("test.txt", []byte("foobar"), 0644))
 			},
@@ -680,7 +680,7 @@ func TestCopyRootfsImage(t *testing.T) {
 			},
 		},
 		{
-			name: "Install nested directories",
+			name: "Create nested directories",
 			initfunc: func(imgpath string) {
 				require.Nil(t, ioutil.WriteFile("test.txt", []byte("foobar"), 0644))
 			},

--- a/cli/mender-artifact/debugfs.go
+++ b/cli/mender-artifact/debugfs.go
@@ -74,12 +74,16 @@ func debugfsCopyFile(file, image string) (ret string, err error) {
 }
 
 func debugfsMakeDir(imageFile, image string) (err error) {
+	_, err = debugfsExecuteCommand(fmt.Sprintf("stat %s", imageFile), image)
+	// If directory already exists, just return
+	if err == nil {
+		return err
+	}
 	// Remove the `/` suffix if present, as debugfs does not play nice with it.
 	imageFile = strings.TrimRight(imageFile, "/")
 	// Recursively create parent directories if they do not exist
 	dir, _ := filepath.Split(imageFile)
-	_, err = os.Stat(dir)
-	if dir != "" && os.IsNotExist(err) {
+	if dir != "" {
 		debugfsMakeDir(dir, image)
 	}
 	cmd := fmt.Sprintf("mkdir %s", imageFile)

--- a/cli/mender-artifact/debugfs.go
+++ b/cli/mender-artifact/debugfs.go
@@ -79,7 +79,7 @@ func debugfsMakeDir(imageFile, image string) (err error) {
 	if err == nil {
 		return err
 	}
-	// Remove the `/` suffix if present, as debugfs does not play nice with it.
+	// Remove the `/` suffix if present, as debugfs mkdir does not play nice with it.
 	imageFile = strings.TrimRight(imageFile, "/")
 	// Recursively create parent directories if they do not exist
 	dir, _ := filepath.Split(imageFile)

--- a/cli/mender-artifact/debugfs.go
+++ b/cli/mender-artifact/debugfs.go
@@ -73,6 +73,22 @@ func debugfsCopyFile(file, image string) (ret string, err error) {
 	return tmpDir, nil
 }
 
+func debugfsMakeDir(imageFile, image string) (err error) {
+	// Remove the `/` suffix if present, as debugfs does not play nice with it.
+	imageFile = strings.TrimRight(imageFile, "/")
+	// Recursively create parent directories if they do not exist
+	dir, _ := filepath.Split(imageFile)
+	_, err = os.Stat(dir)
+	if dir != "" && os.IsNotExist(err) {
+		debugfsMakeDir(dir, image)
+	}
+	cmd := fmt.Sprintf("mkdir %s", imageFile)
+	if _, err = debugfsExecuteCommand(cmd, image); err != nil {
+		return errors.Wrap(err, "debugfsMakeDir")
+	}
+	return nil
+}
+
 func debugfsReplaceFile(imageFile, hostFile, image string) (err error) {
 	// First check that the path exists. (cd path)
 	cmd := fmt.Sprintf("cd %s\nclose", filepath.Dir(imageFile))

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -395,8 +395,8 @@ func getCliContext() *cli.App {
 
 	install := cli.Command{
 		Name:        "install",
-		Usage:       "install -m <permissions> <hostfile> [artifact|sdimg|uefiimg]:<filepath>",
-		Description: "Installs a file from the host filesystem to the artifact or sdimg.",
+		Usage:       "install -m <permissions> <hostfile> [artifact|sdimg|uefiimg]:<filepath> or install -d [artifact|sdimg|uefiimg]:<directory>",
+		Description: "Installs a file or directory from the host filesystem to the artifact or sdimg.",
 		Action:      Install,
 	}
 
@@ -404,6 +404,10 @@ func getCliContext() *cli.App {
 		cli.IntFlag{
 			Name:  "mode, m",
 			Usage: "Set the permission bits in the file",
+		},
+		cli.BoolFlag{
+			Name:  "directory, d",
+			Usage: "Install a directory into an artifact",
 		},
 	}
 

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -396,7 +396,7 @@ func getCliContext() *cli.App {
 	install := cli.Command{
 		Name:        "install",
 		Usage:       "install -m <permissions> <hostfile> [artifact|sdimg|uefiimg]:<filepath> or install -d [artifact|sdimg|uefiimg]:<directory>",
-		Description: "Installs a file or directory from the host filesystem to the artifact or sdimg.",
+		Description: "Installs a directory, or a file from the host filesystem, to the artifact or sdimg.",
 		Action:      Install,
 	}
 
@@ -407,7 +407,7 @@ func getCliContext() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:  "directory, d",
-			Usage: "Install a directory into an artifact",
+			Usage: "Create a directory inside an artifact",
 		},
 	}
 


### PR DESCRIPTION
This PR adds the ability to create directories (and nested directories) to the `mender-artifact install` command, mimicking the `install` utility syntax:
`mender-artifact install -d <artifact>:/dirs/to/create`

Changelog: Title

Signed-off-by: Sam Baxter <sbaxter@izotope.com>