### PR TITLE
Enabled shell auto-completion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,39 @@ For sample usage, please see the [Mender client source code](https://github.com/
 You can find the latest `mender-artifact` binaries in the [Downloads page on
 Mender Docs](https://docs.mender.io/downloads).
 
+## Enabling auto-completion in Bash & ZSH
+
+ auto-completion of `mender-artifact` sub-commands can be added to either ZSH or
+ Bash through:
+
+ ### Bash
+
+ The simplest way of enabling auto-completion in Bash is to copy the
+ `./autocomplete/bash_autocomplete` file into `/etc/bash_completion.d/` like so:
+
+ ```bash
+sudo cp path/to/mender-aritfact/autocomplete/bash_autocomplete /etc/bash_completion.d/mender-artifact
+source /etc/bash_completion.d/mender-artifact
+ ```
+
+ Alternatively the following can be added to `.bashrc`:
+
+ ```bash
+PROG=mender-artifact
+source path/to/mender-artifact/autocomplete/bash_autocomplete
+ ```
+
+ ### ZSH
+
+Auto-completion for ZSH is supported through the `zsh_autocompletion` script
+found in the `./autocomplete` directory. In order to enable it consistently, add
+these lines to your `.zshrc` file:
+
+```bash
+PROG=mender-artifact
+_CLI_ZSH_AUTOCOMPLETE_HACK=1
+source  path/to/mender-artifact/autocomplete/zsh_autocomplete```
+
 
 ## Contributing
 

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,0 +1,13 @@
+#compdef $PROG
+
+_cli_zsh_autocomplete() {
+
+  local -a opts
+  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+
+  _describe 'values' opts
+
+  return
+}
+
+compdef _cli_zsh_autocomplete $PROG

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -67,6 +67,8 @@ func getCliContext() *cli.App {
 	app.Author = "Northern.tech AS"
 	app.Email = "contact@northern.tech"
 
+	app.EnableBashCompletion = true
+
 	compressors := artifact.GetRegisteredCompressorIds()
 
 	compressionFlag := cli.StringFlag{


### PR DESCRIPTION
This PR

* Enables the auto-completion features from the mentioned library
* Documents how to enable it in the Readme

Then writing:

mender-artifact <TAB>

results in:

```
➜ mender-artifact git:(bashexpansion) ✗ mender-artifact
cat          -- cat [artifact|sdimg|uefiimg]:<filepath>
cp           -- cp <src> <dst>
dump         -- Dump contents from Artifacts
help      h  -- Shows a list of commands or help for one command
install      -- install -m <permissions> <hostfile> [artifact|sdimg|uefiimg]
modify       -- Modifies image or artifact file.
read         -- Reads artifact file.
rm           -- rm [artifact|sdimg|uefiimg]:<filepath>
sign         -- Signs existing artifact file.
validate     -- Validates artifact file.
write        -- Writes artifact file.
```

and

```
➜ mender-artifact git:(bashexpansion) ✗ mender-artifact write
help          h  -- Shows a list of commands or help for one command
module-image     -- Writes Mender artifact for an update module
rootfs-image     -- Writes Mender artifact containing rootfs image
```

for sub-commands, once enabled.