### PR TITLE
Restore `module-image -f` flag as optional.

### DIFF
--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -250,7 +250,6 @@ func getCliContext() *cli.App {
 		cli.StringSliceFlag{
 			Name:  "file, f",
 			Usage: "Include `FILE` in payload. Can be given more than once.",
-			Required: true,
 		},
 		cli.StringFlag{
 			Name:  "augment-type",

--- a/cli/mender-artifact/main_test.go
+++ b/cli/mender-artifact/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -131,4 +132,28 @@ func TestCompressionArgumentLocations(t *testing.T) {
 		"-n", "dummy",
 		"-o", menderName,
 	}))
+}
+
+func TestModuleImageWithoutPayload(t *testing.T) {
+	app := getCliContext()
+
+	menderFile, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	menderFile.Close()
+	menderName := menderFile.Name()
+	defer os.Remove(menderName)
+
+	// Default
+	err = app.Run([]string{"mender-artifact",
+		"write",
+		"module-image",
+		"-t", "dummy",
+		"-n", "dummy",
+		"-T", "dummy",
+		"-o", menderName,
+	})
+	assert.NoError(t, err)
+	outputBytes, err := exec.Command("bash", "-c", fmt.Sprintf("tar xOf %s data/0000.tar.gz | tar tz", menderName)).Output()
+	assert.NoError(t, err)
+	assert.Empty(t, string(outputBytes))
 }

--- a/cli/mender-artifact/main_test.go
+++ b/cli/mender-artifact/main_test.go
@@ -42,7 +42,7 @@ func TestCompressionArgumentLocations(t *testing.T) {
 	defer os.Remove(menderName)
 
 	// Default
-	app.Run([]string{"mender-artifact",
+	err = app.Run([]string{"mender-artifact",
 		"write",
 		"rootfs-image",
 		"-f", dummyName,
@@ -50,13 +50,14 @@ func TestCompressionArgumentLocations(t *testing.T) {
 		"-n", "dummy",
 		"-o", menderName,
 	})
+	assert.NoError(t, err)
 	outputBytes, err := exec.Command("tar", "tf", menderName).Output()
 	assert.Contains(t, string(outputBytes), "header.tar.gz")
 	assert.NotContains(t, string(outputBytes), "header.tar.xz")
 	assert.NoError(t, err)
 
 	// Global flag
-	app.Run([]string{"mender-artifact",
+	err = app.Run([]string{"mender-artifact",
 		"--compression", "lzma",
 		"write",
 		"rootfs-image",
@@ -65,13 +66,14 @@ func TestCompressionArgumentLocations(t *testing.T) {
 		"-n", "dummy",
 		"-o", menderName,
 	})
+	assert.NoError(t, err)
 	outputBytes, err = exec.Command("tar", "tf", menderName).Output()
 	assert.Contains(t, string(outputBytes), "header.tar.xz")
 	assert.NotContains(t, string(outputBytes), "header.tar.gz")
 	assert.NoError(t, err)
 
 	// Command flag
-	app.Run([]string{"mender-artifact",
+	err = app.Run([]string{"mender-artifact",
 		"write",
 		"rootfs-image",
 		"-f", dummyName,
@@ -80,13 +82,14 @@ func TestCompressionArgumentLocations(t *testing.T) {
 		"-o", menderName,
 		"--compression", "lzma",
 	})
+	assert.NoError(t, err)
 	outputBytes, err = exec.Command("tar", "tf", menderName).Output()
 	assert.Contains(t, string(outputBytes), "header.tar.xz")
 	assert.NotContains(t, string(outputBytes), "header.tar.gz")
 	assert.NoError(t, err)
 
 	// Overriding with lzma
-	app.Run([]string{"mender-artifact",
+	err = app.Run([]string{"mender-artifact",
 		"--compression", "gzip",
 		"write",
 		"rootfs-image",
@@ -96,13 +99,14 @@ func TestCompressionArgumentLocations(t *testing.T) {
 		"-o", menderName,
 		"--compression", "lzma",
 	})
+	assert.NoError(t, err)
 	outputBytes, err = exec.Command("tar", "tf", menderName).Output()
 	assert.Contains(t, string(outputBytes), "header.tar.xz")
 	assert.NotContains(t, string(outputBytes), "header.tar.gz")
 	assert.NoError(t, err)
 
 	// Overriding with gz
-	app.Run([]string{"mender-artifact",
+	err = app.Run([]string{"mender-artifact",
 		"--compression", "lzma",
 		"write",
 		"rootfs-image",
@@ -112,6 +116,7 @@ func TestCompressionArgumentLocations(t *testing.T) {
 		"-o", menderName,
 		"--compression", "gzip",
 	})
+	assert.NoError(t, err)
 	outputBytes, err = exec.Command("tar", "tf", menderName).Output()
 	assert.Contains(t, string(outputBytes), "header.tar.gz")
 	assert.NotContains(t, string(outputBytes), "header.tar.xz")


### PR DESCRIPTION
```
commit 0e8d4f7d2b35024340f8aabc647b0f6734b972cd
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Tue Jun 2 08:42:38 2020

    Restore `module-image -f` flag as optional.
    
    This was mistakenly made a required flag in da8a2d29da2fd.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit b1ff041eed51fe0ccfd19614f0c0108a95225680
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Tue Jun 2 08:41:49 2020

    test: Add missing error checking after command line parsing.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```