### PR TITLE
Add(Makefile): Target for installing the autocompletion scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,17 @@ build-natives-contained:
 install:
 	cd $(INSTALL_DIR) && $(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 
+install-autocomplete-scripts:
+	@echo "Installing Bash auto-complete script into ${DESTDIR}${PREFIX}/etc/bash_completion.d/"
+	@install -d ${DESTDIR}$(PREFIX)/etc/bash_completion.d/
+	@install -m 644 ./autocomplete/bash_autocomplete $(DESTDIR)$(PREFIX)/etc/bash_completion.d/mender-artifact
+	@if which zsh >/dev/null 2>&1 ; then \
+	echo "Installing zsh auto-complete script into ${DESTDIR}${PREFIX}/usr/local/share/zsh/site-functions/" \
+	install -d $(DESTDIR)$(PREFIX)/usr/local/share/zsh/site-functions/ && \
+	install -m 644 ./autocomplete/zsh_autocomplete $(DESTDIR)$(PREFIX)/usr/local/share/zsh/site-functions/_mender-artifact \
+	; fi
+
+
 clean:
 	$(GO) clean
 	rm -f mender-artifact-darwin mender-artifact-linux mender-artifact-windows.exe

--- a/README.md
+++ b/README.md
@@ -99,9 +99,8 @@ found in the `./autocomplete` directory. In order to enable it consistently, add
 these lines to your `.zshrc` file:
 
 ```bash
-PROG=mender-artifact
-_CLI_ZSH_AUTOCOMPLETE_HACK=1
-source  path/to/mender-artifact/autocomplete/zsh_autocomplete```
+source  path/to/mender-artifact/autocomplete/zsh_autocomplete
+```
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -57,10 +57,25 @@ Mender Docs](https://docs.mender.io/downloads).
 
 ## Enabling auto-completion in Bash & ZSH
 
+### Automatic installation through the Makefile
+
+This is the easiest approach, and all that is needed it to run:
+
+```bash
+sudo make install-autocomplete-scripts
+```
+
+And the `Bash` auto-complete script will be installed to
+`/etc/bash_completion.d`, and if `Zsh` is installed on the system, the
+corresponding auto-completion script is installed into
+`/usr/share/local/zsh/site-functions`.
+
+### Manual installation
+
  auto-completion of `mender-artifact` sub-commands can be added to either ZSH or
  Bash through:
 
- ### Bash
+#### Bash
 
  The simplest way of enabling auto-completion in Bash is to copy the
  `./autocomplete/bash_autocomplete` file into `/etc/bash_completion.d/` like so:
@@ -77,7 +92,7 @@ PROG=mender-artifact
 source path/to/mender-artifact/autocomplete/bash_autocomplete
  ```
 
- ### ZSH
+ #### ZSH
 
 Auto-completion for ZSH is supported through the `zsh_autocompletion` script
 found in the `./autocomplete` directory. In order to enable it consistently, add

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,6 +1,6 @@
-#compdef $PROG
+#compdef _mender-artifact mender-artifact
 
-_cli_zsh_autocomplete() {
+_mender-artifact() {
 
   local -a opts
   local cur
@@ -20,4 +20,4 @@ _cli_zsh_autocomplete() {
   return
 }
 
-compdef _cli_zsh_autocomplete $PROG
+compdef _mender-artifact mender-artifact


### PR DESCRIPTION
Simply add a Makefile target for installing the autocompletion scripts.