### PR TITLE
PoC: Dynamically load mender-artifact update module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,16 @@ build-natives-contained:
 	docker run --rm --entrypoint "/bin/sh" -v $(shell pwd):/binary $$image_id -c "cp /go/bin/mender-artifact* /binary" && \
 	docker image rm $$image_id
 
+build-plugins:
+	@echo "Building the mender-artifact plugins..."
+	@for plugin in $(shell ls ./plug-source/*.go); do \
+		go build -o ./plug-source -buildmode=plugin $$plugin ; \
+	done
+
+install-plugins:
+	@echo "Installing the mender-artifact plugins..."
+	@install -D --target-directory /etc/mender-artifact/.mender-artifact-plugins ./plug-source/*.so
+
 install:
 	cd $(INSTALL_DIR) && $(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
 

--- a/plug-source/k8s.go
+++ b/plug-source/k8s.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+	"os/exec"
+	"github.com/pkg/errors"
+)
+
+func generateK8sArtifact(c *cli.Context) (err error) {
+	var cmd *exec.Cmd
+	for _, manifesto := range c.StringSlice("manifestos") {
+		cmd = exec.Command("kubectl", "apply", "--dry-run", "-f", manifesto)
+		if err = cmd.Run(); err != nil {
+			return errors.Wrapf(err, "The manifesto: %q is not a valid manifesto. Aborting",
+				manifesto)
+		}
+	}
+	fmt.Println("wrote k8s update-module artifact")
+	return nil
+}
+
+func CLI() cli.Command {
+	writeModuleCommand := cli.Command{
+		Name:      "k8s",
+		Action:    generateK8sArtifact,
+		Usage:     "Writes Mender artifact for an k8s update module",
+		UsageText: "Writes a k8s Mender artifact that will be used by the k8s update module. ",
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name:     "manifestos, ma",
+				Usage:    "Path(s) to the Kubernetes manifesto(s)",
+				Required: true,
+			},
+		},
+	}
+
+	return writeModuleCommand
+}


### PR DESCRIPTION
# PoC - Plugin functionality

This is a PoC of the concept of dynamically loading functionality into `mender-artifact`.

The idea is to collect the somewhat disparate functionality present in our `generate-<update-module>` scripts. And pull them all back into `mender-artifact`, which is where they belong imo.

This way, every `generator` script we now have, can be collected into `mender-artifact`, which:
* increases the visibility and discover-ability of the update-modules available.
* gives all update-module functionality auto-completion, and full help-text directly in the tool. No `-- <discover-the-mender-artifact-flags-yourself>` prints.
* gives us the opportunity to distribute the `delta` generator as a plugin to `mender-artifact`, as compared to a separate script.
* It removes the need for hacks, such as the `dump` command, as plugins can work directly with the existing `mender-artifact` functionality. No need to serialize, and deserialize data.

There are some cons which should be noted, as they can come back and bite us, if not handled properly. (See [cons](#cons))

## Old vs New functionality

### Old

```
$ Download the specific generator tool
$ <run-script> -- <non-discoverable-mender-artifact-flags>
```

### New

```
$ mender-artifact generate -h
NAME:
   mender-artifact generate - Generates special Artifacts

USAGE:
   mender-artifact generate command [command options] [arguments...]

COMMANDS:
   delta  Writes Mender artifact for an delta update module
   k8s    Writes Mender artifact for an k8s update module

OPTIONS:
   --help, -h  show help
```
```
$ mender-artifact git:(pluginpoc) ✗ ./mender-artifact generate k8s -h
NAME:
   mender-artifact generate k8s - Writes Mender artifact for an k8s update module

USAGE:
   Writes a k8s Mender artifact that will be used by the k8s update module. 

REQUIRED ARGUMENTS:
   --artifact-name value, -n value  Name of the artifact
   --device-type value, -t value    Type of device(s) supported by the Artifact. You can specify multiple compatible devices providing this parameter multiple times.
   --manifestos value, --ma value   Path(s) to the Kubernetes manifesto(s)

OPTIONS:
   --artifact-name-depends value, -N value  Sets the name(s) of the artifact(s) which this update depends upon
   --augment-depends KEY:VALUE              Generic KEY:VALUE which is added to the augmented type-info -> artifact_depends section. Can be given multiple times
   --augment-file FILE                      Include FILE in payload in the augment section. Can be given more than once.
   --augment-meta-data FILE                 The meta-data JSON FILE for this payload, for the augmented section
   --augment-provides KEY:VALUE             Generic KEY:VALUE which is added to the augmented type-info -> artifact_provides section. Can be given multiple times
   --augment-type value                     Type of augmented payload. This is the same as the name of the update module
   --compression value                      Compression to use for data and header inside the artifact, currently supports: none, gzip, lzma.
   --depends KEY:VALUE, -d KEY:VALUE        Generic KEY:VALUE which is added to the type-info -> artifact_depends section. Can be given multiple times
   --depends-groups value, -G value         The group(s) the artifact depends on
   --file FILE, -f FILE                     Include FILE in payload. Can be given more than once.
   --key value, -k value                    Full path to the private key that will be used to sign the artifact.
   --meta-data FILE, -m FILE                The meta-data JSON FILE for this payload
   --output-path value, -o value            Full path to output artifact file.
   --provides KEY:VALUE, -p KEY:VALUE       Generic KEY:VALUE which is added to the type-info -> artifact_provides section. Can be given multiple times
   --provides-group value, -g value         The group the artifact provides
   --script value, -s value                 Full path to the state script(s). You can specify multiple scripts providing this parameter multiple times.
   --version value, -v value                Version of the artifact. (default: 3)
```

Which perfectly matches the functionality already present in `mender-artifact`, except this can be extended to any other update-module at runtime by creating a plugin.

Or, if autocompletion is installed, you can <tab> yourself to find the options available interactively. 
   


## Comments on the CLI command tree chosen

In general, I think there are two ways to go about the CLI here:

1. In this PoC a new CLI option `generate`, will show up in the first submenu, if a plugin is found. (which is what this PR does)
2. Is to add them under the existing `write module-image` command, perhaps cleaner?

> I'd like to discuss which approach is favoured here.

For this commit, that is a dummy `k8s` module, which simply validates a manifesto file. Extending it to full functionality is easy though.

To test this locally, do:
```
$ sudo make build build-plugins install-plugins
$ ./mender-artifact generate -h
# ./mender-artifact generate k8s --manifestos <some-manifesto-or-dummy-file> -n foo -t bar
```

For extra visibility, have the autocompletion functionality installed (optional, but recommended):

```
$ sudo make install-autocomplete-scripts
```

## Cons
This relies on the `plugin` module in go, to dynamically load the plugin at runtime. This does have some serious drawbacks, which we should be aware of.

The plugin and the `mender-artifact` binary, has to be built with the same version of `go`, and the same version of the packages they both share (notably `urfave/cli`).  In general I think this can be solved, simply by having them as a part of the release process, so that they are built and distributed in and from the same environment. 

For someone not happy with `go plugins`, see [reddit](https://www.reddit.com/r/golang/comments/b6h8qq/is_anyone_actually_using_go_plugins/)

I guess this can be solved through always building with our Docker build files?
