### PR TITLE
MEN-3076,MEN-3077: set software version in {rootfs,module}-image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
-image: golang:1.11-alpine3.9
+image: golang:1.14-alpine3.11
 
 cache:
   paths:

--- a/Documentation/artifact-format-v3.md
+++ b/Documentation/artifact-format-v3.md
@@ -256,10 +256,10 @@ It can also contain some additional parameters extending or modifying the global
 {
   "type": "rootfs-image"
   "artifact_provides": {
-      "rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
+      "rootfs-image.checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
   },
   "artifact_depends": {
-      "rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
+      "rootfs-image.checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
   },
 }
 ```
@@ -382,12 +382,12 @@ These files and attributes are allowed:
   disable overriding for that entry, which may be necessary in order to get
   indexing right if some entries are overriden, but not all.
 
-* `type-info` file with `artifact_depends` and `rootfs_image_checksum`:
+* `type-info` file with `artifact_depends` and `rootfs-image.checksum`:
   ```
   {
     "type": "rootfs-image"
     "artifact_depends": {
-        "rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
+        "rootfs-image.checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
     },
   }
   ```

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ get-tools:
 		echo "-- go getting $$t"; \
 		go get -u $$t; \
 	done
+	go mod vendor
 
 check: test extracheck
 
@@ -112,7 +113,7 @@ extracheck:
 		/bin/false; \
 	fi
 	echo "-- checking with govet"
-	$(GO) tool vet -unsafeptr=false $(PKGFILES_notest)
+	$(GO) vet -unsafeptr=false
 	echo "-- checking for dead code"
 	deadcode
 	echo "-- checking with varcheck"

--- a/artifact/metadata_test.go
+++ b/artifact/metadata_test.go
@@ -336,19 +336,19 @@ func TestMarshalJSONTypeInfoV3(t *testing.T) {
 			ti: TypeInfoV3{
 				Type: "delta",
 				ArtifactDepends: TypeInfoDepends{
-					"rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619",
+					"rootfs-image.checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619",
 				},
 				ArtifactProvides: TypeInfoProvides{
-					"rootfs_image_checksum": "853jsdfh342789sdflkjsdf987324kljsdf987234kjljsdf987234klsdf987d8",
+					"rootfs-image.checksum": "853jsdfh342789sdflkjsdf987324kljsdf987234kjljsdf987234klsdf987d8",
 				},
 			},
 			expected: `{
 				"type": "delta",
 				"artifact_depends": {
-					"rootfs_image_checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
+					"rootfs-image.checksum": "4d480539cdb23a4aee6330ff80673a5af92b7793eb1c57c4694532f96383b619"
 				},
 				"artifact_provides": {
-					"rootfs_image_checksum": "853jsdfh342789sdflkjsdf987324kljsdf987234kjljsdf987234klsdf987d8"
+					"rootfs-image.checksum": "853jsdfh342789sdflkjsdf987324kljsdf987234kjljsdf987234klsdf987d8"
 				}
 			      }`,
 		},

--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -330,13 +330,13 @@ func repack(comp artifact.Compressor, ua *unpackedArtifact, to io.Writer, key []
 		aWriter = awriter.NewWriterSigned(to, comp, artifact.NewSigner(key))
 	}
 
-	// for rootfs-images: Update rootfs_image_checksum provide if there is one.
-	_, hasChecksumProvide := ua.writeArgs.TypeInfoV3.ArtifactProvides["rootfs_image_checksum"]
+	// for rootfs-images: Update rootfs-image.checksum provide if there is one.
+	_, hasChecksumProvide := ua.writeArgs.TypeInfoV3.ArtifactProvides["rootfs-image.checksum"]
 	if ua.writeArgs.TypeInfoV3.Type == "rootfs-image" && hasChecksumProvide {
 		if len(ua.files) != 1 {
 			return errors.New("Only rootfs-image Artifacts with one file are supported")
 		}
-		err := writeRootfsImageChecksum(ua.files[0], ua.writeArgs.TypeInfoV3)
+		err := writeRootfsImageChecksum(ua.files[0], ua.writeArgs.TypeInfoV3, false)
 		if err != nil {
 			return err
 		}

--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -332,11 +332,13 @@ func repack(comp artifact.Compressor, ua *unpackedArtifact, to io.Writer, key []
 
 	// for rootfs-images: Update rootfs-image.checksum provide if there is one.
 	_, hasChecksumProvide := ua.writeArgs.TypeInfoV3.ArtifactProvides["rootfs-image.checksum"]
-	if ua.writeArgs.TypeInfoV3.Type == "rootfs-image" && hasChecksumProvide {
+	// for rootfs-images: Update legacy rootfs_image_checksum provide if there is one.
+	_, hasLegacyChecksumProvide := ua.writeArgs.TypeInfoV3.ArtifactProvides["rootfs_image_checksum"]
+	if ua.writeArgs.TypeInfoV3.Type == "rootfs-image" && (hasChecksumProvide || hasLegacyChecksumProvide) {
 		if len(ua.files) != 1 {
 			return errors.New("Only rootfs-image Artifacts with one file are supported")
 		}
-		err := writeRootfsImageChecksum(ua.files[0], ua.writeArgs.TypeInfoV3, false)
+		err := writeRootfsImageChecksum(ua.files[0], ua.writeArgs.TypeInfoV3, hasLegacyChecksumProvide)
 		if err != nil {
 			return err
 		}

--- a/cli/mender-artifact/artifacts_test.go
+++ b/cli/mender-artifact/artifacts_test.go
@@ -163,14 +163,14 @@ func WriteArtifact(dir string, ver int, update string) error {
 		Type: "rootfs-image",
 		// Keeping these empty for now. We will likely introduce these
 		// later, when we add support for augmented artifacts.
-		// ArtifactDepends:  &artifact.TypeInfoDepends{"rootfs_image_checksum": c.String("depends-rootfs-image-checksum")},
-		// ArtifactProvides: &artifact.TypeInfoProvides{"rootfs_image_checksum": c.String("provides-rootfs-image-checksum")},
+		// ArtifactDepends:  &artifact.TypeInfoDepends{"rootfs-image.checksum": c.String("depends-rootfs-image-checksum")},
+		// ArtifactProvides: &artifact.TypeInfoProvides{"rootfs-image.checksum": c.String("provides-rootfs-image-checksum")},
 		ArtifactDepends:  artifact.TypeInfoDepends{},
 		ArtifactProvides: artifact.TypeInfoProvides{},
 	}
 
 	if ver >= 3 {
-		err = writeRootfsImageChecksum(update, &typeInfoV3)
+		err = writeRootfsImageChecksum(update, &typeInfoV3, false)
 		if err != nil {
 			return err
 		}

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -630,7 +630,7 @@ func TestCopyRootfsImage(t *testing.T) {
 			},
 		},
 		{
-			name: "Make sure that rootfs_image_checksum is updated when repacking Artifact",
+			name: "Make sure that rootfs-image.checksum is updated when repacking Artifact",
 			initfunc: func(imgpath string) {
 				require.Nil(t, ioutil.WriteFile("foo.txt", []byte("foobar"), 0644))
 			},
@@ -656,7 +656,7 @@ func TestCopyRootfsImage(t *testing.T) {
 
 				provides, err := inst[0].GetUpdateProvides()
 				require.NoError(t, err)
-				assert.Equal(t, string(inst[0].GetUpdateFiles()[0].Checksum), provides["rootfs_image_checksum"])
+				assert.Equal(t, string(inst[0].GetUpdateFiles()[0].Checksum), provides["rootfs-image.checksum"])
 			},
 		},
 		{

--- a/cli/mender-artifact/dump_test.go
+++ b/cli/mender-artifact/dump_test.go
@@ -109,7 +109,8 @@ func testDumpContent(t *testing.T, imageType string) {
 		"-d", "testDepends:someDep",
 		"-p", "testProvides:someProv",
 		"-g", "providesGroup",
-		"-G", "dependsGroup"})
+		"-G", "dependsGroup",
+		"--no-default-software-version"})
 	require.NoError(t, err)
 
 	printed, err := runAndCollectStdout([]string{"mender-artifact", "dump",

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -17,8 +17,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 	"sort"
+	"strings"
 
 	"github.com/mendersoftware/mender-artifact/artifact"
 
@@ -34,6 +34,13 @@ const (
 	errArtifactInvalid
 	errArtifactUnsupportedFeature
 	errSystemError
+)
+
+const (
+	noDefaultSoftwareVersionFlag = "no-default-software-version"
+	softwareNameFlag             = "software-name"
+	softwareVersionFlag          = "software-version"
+	softwareFilesystemFlag       = "software-filesystem"
 )
 
 // Version of the mender-artifact CLI tool
@@ -97,8 +104,8 @@ func getCliContext() *cli.App {
 	// Common Artifact flags
 	//
 	artifactName := cli.StringFlag{
-		Name:  "artifact-name, n",
-		Usage: "Name of the artifact",
+		Name:     "artifact-name, n",
+		Usage:    "Name of the artifact",
 		Required: true,
 	}
 	artifactNameDepends := cli.StringSliceFlag{
@@ -112,6 +119,24 @@ func getCliContext() *cli.App {
 	artifactDependsGroups := cli.StringSliceFlag{
 		Name:  "depends-groups, G",
 		Usage: "The group(s) the artifact depends on",
+	}
+
+	// Common Software Version flags
+	softwareVersionNoDefault := cli.BoolFlag{
+		Name:  noDefaultSoftwareVersionFlag,
+		Usage: "Disable the software version field for compatibility with old clients",
+	}
+	softwareVersionName := cli.StringFlag{
+		Name:  softwareNameFlag,
+		Usage: "Name of the key to store the software version: rootfs-image.NAME.version, instead of rootfs-image.version",
+	}
+	softwareVersionValue := cli.StringFlag{
+		Name:  softwareVersionFlag,
+		Usage: "Value for the software version, defaults to the name of the artifact",
+	}
+	softwareFilesystem := cli.StringFlag{
+		Name:  softwareFilesystemFlag,
+		Usage: "If specified, is used instead of rootfs-image",
 	}
 
 	//
@@ -191,6 +216,13 @@ func getCliContext() *cli.App {
 		payloadDepends,
 		payloadProvides,
 		compressionFlag,
+		//////////////////////
+		// Sotware versions //
+		//////////////////////
+		softwareVersionNoDefault,
+		softwareVersionName,
+		softwareVersionValue,
+		softwareFilesystem,
 	}
 
 	writeRootfsCommand.Before = applyCompressionInCommand
@@ -240,8 +272,8 @@ func getCliContext() *cli.App {
 		artifactProvidesGroup,
 		artifactDependsGroups,
 		cli.StringFlag{
-			Name:  "type, T",
-			Usage: "Type of payload. This is the same as the name of the update module",
+			Name:     "type, T",
+			Usage:    "Type of payload. This is the same as the name of the update module",
 			Required: true,
 		},
 		payloadProvides,
@@ -272,12 +304,19 @@ func getCliContext() *cli.App {
 			Usage: "Include `FILE` in payload in the augment section. Can be given more than once.",
 		},
 		compressionFlag,
+		//////////////////////
+		// Sotware versions //
+		//////////////////////
+		softwareVersionNoDefault,
+		softwareVersionName,
+		softwareVersionValue,
+		softwareFilesystem,
 	}
 	writeModuleCommand.Before = applyCompressionInCommand
 
 	writeCommand := cli.Command{
-		Name:  "write",
-		Usage: "Writes artifact file.",
+		Name:     "write",
+		Usage:    "Writes artifact file.",
 		Category: "Artifact creation and validation",
 		Subcommands: []cli.Command{
 			writeRootfsCommand,
@@ -291,7 +330,7 @@ func getCliContext() *cli.App {
 	validate := cli.Command{
 		Name:        "validate",
 		Usage:       "Validates artifact file.",
-		Category: "Artifact creation and validation",
+		Category:    "Artifact creation and validation",
 		Action:      validateArtifact,
 		UsageText:   "mender-artifact validate [options] <pathspec>",
 		Description: "This command validates artifact file provided by pathspec.",
@@ -305,7 +344,7 @@ func getCliContext() *cli.App {
 		Name:        "read",
 		Usage:       "Reads artifact file.",
 		ArgsUsage:   "<artifact path>",
-		Category: "Artifact creation and validation",
+		Category:    "Artifact creation and validation",
 		Action:      readArtifact,
 		Description: "This command validates artifact file provided by pathspec.",
 		Flags:       []cli.Flag{publicKeyFlag},
@@ -318,7 +357,7 @@ func getCliContext() *cli.App {
 
 		Name:        "sign",
 		Usage:       "Signs existing artifact file.",
-		Category: "Artifact modification",
+		Category:    "Artifact modification",
 		Action:      signExisting,
 		UsageText:   "mender-artifact sign [options] <pathspec>",
 		Description: "This command signs artifact file provided by pathspec.",
@@ -342,7 +381,7 @@ func getCliContext() *cli.App {
 	modify := cli.Command{
 		Name:        "modify",
 		Usage:       "Modifies image or artifact file.",
-		Category: "Artifact modification",
+		Category:    "Artifact modification",
 		Action:      modifyArtifact,
 		UsageText:   "mender-artifact modify [options] <pathspec>",
 		Description: "This command modifies existing image or artifact file provided by pathspec. NOTE: Currently only ext4 payloads can be modified",
@@ -394,7 +433,7 @@ func getCliContext() *cli.App {
 	copy := cli.Command{
 		Name:        "cp",
 		Usage:       "cp <src> <dst>",
-		Category: "Artifact modification",
+		Category:    "Artifact modification",
 		Description: "Copies a file into or out of a mender artifact, or sdimg",
 		UsageText: "Copy from or into an artifact, or sdimg where either the <src>" +
 			" or <dst> has to be of the form [artifact|sdimg]:<filepath>, <src> can" +
@@ -412,7 +451,7 @@ func getCliContext() *cli.App {
 		Name:        "cat",
 		Usage:       "cat [artifact|sdimg|uefiimg]:<filepath>",
 		Description: "Cat can output a file from a mender artifact or mender image to stdout.",
-		Category: "Artifact modification",
+		Category:    "Artifact modification",
 		Action:      Cat,
 	}
 
@@ -420,7 +459,7 @@ func getCliContext() *cli.App {
 		Name:        "install",
 		Usage:       "install -m <permissions> <hostfile> [artifact|sdimg|uefiimg]:<filepath> or install -d [artifact|sdimg|uefiimg]:<directory>",
 		Description: "Installs a directory, or a file from the host filesystem, to the artifact or sdimg.",
-		Category: "Artifact modification",
+		Category:    "Artifact modification",
 		Action:      Install,
 	}
 
@@ -438,7 +477,7 @@ func getCliContext() *cli.App {
 	remove := cli.Command{
 		Name:        "rm",
 		Usage:       "rm [artifact|sdimg|uefiimg]:<filepath>",
-		Category: "Artifact modification",
+		Category:    "Artifact modification",
 		Description: "Removes the given file or directory from an Artifact or sdimg.",
 		Action:      Remove,
 	}

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -126,10 +126,6 @@ func getCliContext() *cli.App {
 		Name:  noDefaultSoftwareVersionFlag,
 		Usage: "Disable the software version field for compatibility with old clients",
 	}
-	softwareVersionName := cli.StringFlag{
-		Name:  softwareNameFlag,
-		Usage: "Name of the key to store the software version: rootfs-image.NAME.version, instead of rootfs-image.version",
-	}
 	softwareVersionValue := cli.StringFlag{
 		Name:  softwareVersionFlag,
 		Usage: "Value for the software version, defaults to the name of the artifact",
@@ -225,7 +221,10 @@ func getCliContext() *cli.App {
 		// Sotware versions //
 		//////////////////////
 		softwareVersionNoDefault,
-		softwareVersionName,
+		cli.StringFlag{
+			Name:  softwareNameFlag,
+			Usage: "Name of the key to store the software version: rootfs-image.NAME.version, instead of rootfs-image.version",
+		},
 		softwareVersionValue,
 		softwareFilesystem,
 	}
@@ -313,7 +312,10 @@ func getCliContext() *cli.App {
 		// Sotware versions //
 		//////////////////////
 		softwareVersionNoDefault,
-		softwareVersionName,
+		cli.StringFlag{
+			Name:  softwareNameFlag,
+			Usage: "Name of the key to store the software version: rootfs-image.NAME.version, instead of rootfs-image.PAYLOAD_TYPE.version",
+		},
 		softwareVersionValue,
 		softwareFilesystem,
 	}

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -196,6 +196,11 @@ func getCliContext() *cli.App {
 				"scripts providing this parameter multiple times.",
 		},
 		cli.BoolFlag{
+			Name: "legacy-rootfs-image-checksum",
+			Usage: "Use the legacy key name rootfs_image_checksum to store the providese checksum " +
+				"to the Artifact provides parameters instead of rootfs-image.checksum.",
+		},
+		cli.BoolFlag{
 			Name: "no-checksum-provide",
 			Usage: "Disable writing the provides checksum to the Artifact provides " +
 				"parameters. This is needed in case the targeted devices do not support " +

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -345,6 +345,7 @@ Updates:
     0:
     Type:   rootfs-image
     Provides:
+	rootfs-image.version: release-1
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -372,6 +373,7 @@ Updates:
     0:
     Type:   rootfs-image
     Provides:
+	rootfs-image.version: release-1
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -426,6 +428,7 @@ Updates:
     0:
     Type:   rootfs-image
     Provides:
+	rootfs-image.version: release-1
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -478,7 +481,8 @@ func TestModifyModuleArtifact(t *testing.T) {
 Updates:
     0:
     Type:   testType
-    Provides: Nothing
+    Provides:
+	rootfs-image.version: testName
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -574,7 +578,8 @@ Updates:
 Updates:
     0:
     Type:   testType
-    Provides: Nothing
+    Provides:
+	rootfs-image.version: testName
     Depends: Nothing
     Metadata:
 	{

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -295,7 +295,7 @@ func removeVolatileEntries(input string) string {
 	for _, line := range strings.Split(input, "\n") {
 		if strings.HasPrefix(line, "      checksum:") ||
 			strings.HasPrefix(line, "      modified:") ||
-			strings.HasPrefix(line, "\trootfs_image_checksum:") {
+			strings.HasPrefix(line, "\trootfs-image.checksum:") {
 			continue
 		}
 		output.WriteString(line)
@@ -634,7 +634,7 @@ func TestModifyExtraAttributes(t *testing.T) {
 		// put it here to make sure that the modification logic
 		// *doesn't* modify it, since this belongs only to the
 		// rootfs-image domain.
-		"-p", "rootfs_image_checksum:test",
+		"-p", "rootfs-image.checksum:test",
 	}
 	err = run()
 	require.NoError(t, err)

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -482,7 +482,7 @@ Updates:
     0:
     Type:   testType
     Provides:
-	rootfs-image.version: testName
+	rootfs-image.testType.version: testName
     Depends: Nothing
     Metadata: Nothing
     Files:
@@ -579,7 +579,7 @@ Updates:
     0:
     Type:   testType
     Provides:
-	rootfs-image.version: testName
+	rootfs-image.testType.version: testName
     Depends: Nothing
     Metadata:
 	{

--- a/cli/mender-artifact/read_test.go
+++ b/cli/mender-artifact/read_test.go
@@ -177,8 +177,8 @@ Updates:
     0:
     Type:   rootfs-image
     Provides:
+	rootfs-image.checksum: ee7cd8c4f4613a5dd2bf585815a77209a13ea7410aa5dedcc8654993b30a4972
 	rootfs-image.version: testName
-	rootfs_image_checksum: ee7cd8c4f4613a5dd2bf585815a77209a13ea7410aa5dedcc8654993b30a4972
     Depends: Nothing
     Metadata: Nothing
     Files:

--- a/cli/mender-artifact/read_test.go
+++ b/cli/mender-artifact/read_test.go
@@ -126,6 +126,7 @@ Updates:
 	augmentProvideKey1: augmentProvideValue1
 	augmentProvideKey2: augmentProvideValue2
 	overrideProvideKey: augmentOverrideProvideValue
+	rootfs-image.version: testName
 	testProvideKey1: testProvideValue1
 	testProvideKey2: testProvideValue2
     Depends:
@@ -176,6 +177,7 @@ Updates:
     0:
     Type:   rootfs-image
     Provides:
+	rootfs-image.version: testName
 	rootfs_image_checksum: ee7cd8c4f4613a5dd2bf585815a77209a13ea7410aa5dedcc8654993b30a4972
     Depends: Nothing
     Metadata: Nothing

--- a/cli/mender-artifact/read_test.go
+++ b/cli/mender-artifact/read_test.go
@@ -126,7 +126,7 @@ Updates:
 	augmentProvideKey1: augmentProvideValue1
 	augmentProvideKey2: augmentProvideValue2
 	overrideProvideKey: augmentOverrideProvideValue
-	rootfs-image.version: testName
+	rootfs-image.testType.version: testName
 	testProvideKey1: testProvideValue1
 	testProvideKey2: testProvideValue2
     Depends:

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -25,14 +25,15 @@ import (
 	"syscall"
 	"time"
 
+	"io"
+	"io/ioutil"
+
 	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/awriter"
 	"github.com/mendersoftware/mender-artifact/cli/mender-artifact/util"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"io"
-	"io/ioutil"
 )
 
 func writeRootfsImageChecksum(rootfsFilename string,

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -553,11 +553,6 @@ func extractKeyValues(params []string) (*map[string]string, error) {
 					fmt.Sprintf("argument must have a delimiting colon: %s", arg),
 					errArtifactInvalidParameters)
 			}
-			if _, exists := (*keyValues)[split[0]]; exists {
-				return nil, cli.NewExitError(
-					fmt.Sprintf("argument specified more than once: %s", split[0]),
-					errArtifactInvalidParameters)
-			}
 			(*keyValues)[split[0]] = split[1]
 		}
 	}

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -519,6 +519,28 @@ func TestWriteRootfsArtifactDependsAndProvidesOverrides(t *testing.T) {
 			},
 			softwareVersion: "v2",
 		},
+		"override with software-version and provides": {
+			args: []string{
+				"mender-artifact", "write", "rootfs-image",
+				"-t", "mydevice",
+				"-o", artfile,
+				"-f", filepath.Join(updateTestDir, "update.ext4"),
+				"-n", "testName",
+				"-N", "testNameDepends1",
+				"-N", "testNameDepends2",
+				"-G", "testGroupDepends1",
+				"-G", "testGroupDepends2",
+				"-g", "testGroupProvide",
+				"-d", "testDependKey1:testDependValue1",
+				"-d", "testDependKey2:testDependValue2",
+				"-p", "testProvideKey1:testProvideValue1",
+				"-p", "testProvideKey2:testProvideValue2",
+				"-p", "rootfs-image.version:v1",
+				"--software-version", "v2",
+				"-p", "rootfs-image.version:v3",
+			},
+			softwareVersion: "v3",
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -395,8 +395,8 @@ func TestWriteRootfsArtifactDependsAndProvides(t *testing.T) {
 	updProvides, err := handler.GetUpdateProvides()
 	require.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoProvides{
-		// `rootfs_image_checksum` is always enabled
-		"rootfs_image_checksum": "bfb4567944c5730face9f3d54efc0c1ff3b5dd1338862b23b849ac87679e162f",
+		// `rootfs-image.checksum` is always enabled
+		"rootfs-image.checksum": "bfb4567944c5730face9f3d54efc0c1ff3b5dd1338862b23b849ac87679e162f",
 		"testProvideKey1":       "testProvideValue1",
 		"testProvideKey2":       "testProvideValue2",
 		"rootfs-image.version":  "testName",
@@ -541,7 +541,7 @@ func TestWriteRootfsArtifactDependsAndProvidesOverrides(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, artifact.TypeInfoProvides{
-				"rootfs_image_checksum": "bfb4567944c5730face9f3d54efc0c1ff3b5dd1338862b23b849ac87679e162f",
+				"rootfs-image.checksum": "bfb4567944c5730face9f3d54efc0c1ff3b5dd1338862b23b849ac87679e162f",
 				"testProvideKey1":       "testProvideValue1",
 				"testProvideKey2":       "testProvideValue2",
 				"rootfs-image.version":  tc.softwareVersion,
@@ -553,7 +553,7 @@ func TestWriteRootfsArtifactDependsAndProvidesOverrides(t *testing.T) {
 func TestWriteRootfsImageChecksum(t *testing.T) {
 
 	// Cannot find payload file (nonexisting)
-	err := writeRootfsImageChecksum("idonotexist", nil)
+	err := writeRootfsImageChecksum("idonotexist", nil, false)
 	assert.Contains(t, err.Error(), "Failed to open the payload file")
 
 	// Checksum a dummy file
@@ -563,12 +563,19 @@ func TestWriteRootfsImageChecksum(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tf.Close())
 	typeInfo := artifact.TypeInfoV3{}
-	err = writeRootfsImageChecksum(tf.Name(), &typeInfo)
+
+	err = writeRootfsImageChecksum(tf.Name(), &typeInfo, false)
 	assert.NoError(t, err)
 	require.NotNil(t, typeInfo.ArtifactProvides)
-	_, ok := typeInfo.ArtifactProvides["rootfs_image_checksum"]
+	_, ok := typeInfo.ArtifactProvides["rootfs-image.checksum"]
 	assert.True(t, ok)
 
+	// legacy key
+	err = writeRootfsImageChecksum(tf.Name(), &typeInfo, true)
+	assert.NoError(t, err)
+	require.NotNil(t, typeInfo.ArtifactProvides)
+	_, ok = typeInfo.ArtifactProvides["rootfs_image_checksum"]
+	assert.True(t, ok)
 }
 
 func TestGetArtifactProvides(t *testing.T) {

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -274,10 +274,10 @@ func TestWriteModuleImage(t *testing.T) {
 
 	updProvides := handler.GetUpdateOriginalProvides()
 	assert.Equal(t, artifact.TypeInfoProvides{
-		"testProvideKey1":      "testProvideValue1",
-		"testProvideKey2":      "testProvideValue2",
-		"overrideProvideKey":   "originalOverrideProvideValue",
-		"rootfs-image.version": "testName",
+		"testProvideKey1":               "testProvideValue1",
+		"testProvideKey2":               "testProvideValue2",
+		"overrideProvideKey":            "originalOverrideProvideValue",
+		"rootfs-image.testType.version": "testName",
 	}, updProvides)
 	updProvides = handler.GetUpdateAugmentProvides()
 	assert.Equal(t, artifact.TypeInfoProvides{
@@ -288,12 +288,12 @@ func TestWriteModuleImage(t *testing.T) {
 	updProvides, err = handler.GetUpdateProvides()
 	require.NoError(t, err)
 	assert.Equal(t, artifact.TypeInfoProvides{
-		"testProvideKey1":      "testProvideValue1",
-		"testProvideKey2":      "testProvideValue2",
-		"augmentProvideKey1":   "augmentProvideValue1",
-		"augmentProvideKey2":   "augmentProvideValue2",
-		"overrideProvideKey":   "augmentOverrideProvideValue",
-		"rootfs-image.version": "testName",
+		"testProvideKey1":               "testProvideValue1",
+		"testProvideKey2":               "testProvideValue2",
+		"augmentProvideKey1":            "augmentProvideValue1",
+		"augmentProvideKey2":            "augmentProvideValue2",
+		"overrideProvideKey":            "augmentOverrideProvideValue",
+		"rootfs-image.testType.version": "testName",
 	}, updProvides)
 
 	assert.Equal(t, map[string]interface{}{"metadata": "test"}, handler.GetUpdateOriginalMetaData())


### PR DESCRIPTION
This PR also includes MEN-3482: Change rootfs_image_checksum over to use namespaced provides.

Depends on:
* https://github.com/mendersoftware/integration/pull/1016
* https://github.com/mendersoftware/meta-mender/pull/1093
* https://github.com/mendersoftware/meta-mender/pull/1096