### PR TITLE
MEN-3075: Implement function for filtering provides with clears_provides.

### DIFF
--- a/utils/attributes.go
+++ b/utils/attributes.go
@@ -1,0 +1,76 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Given a string list containg attribute names, and a string list containing
+// attribute name wildcard expressions, return the list of attributes that match
+// at least one of the expressions. Only '*' wildcard is supported at the
+// moment, matching any number of characters, including zero.
+//
+// This is intended to be used to match `artifact_provides` attributes against
+// `clears_artifact_provides` attributes.
+func StringsMatchingWildcards(attributes, wildcards []string) ([]string, error) {
+	regexes := make([](*regexp.Regexp), 0, len(wildcards))
+
+	// Turn into regular expression.
+	for _, wildcard := range wildcards {
+		b := strings.Builder{}
+		b.WriteRune('^')
+		for i := range wildcard {
+			switch wildcard[i] {
+			case '\\':
+				if i+1 >= len(wildcard) {
+					return nil, errors.Errorf(
+						"Expression cannot end with a backslash: \"%s\"",
+						wildcard)
+				}
+				b.WriteString(wildcard[i:i+2])
+				i++
+
+			case '*':
+				b.WriteString(".*")
+
+			default:
+				b.WriteString(regexp.QuoteMeta(wildcard[i:i+1]))
+			}
+		}
+		b.WriteRune('$')
+		regex, err := regexp.Compile(b.String())
+		if err != nil {
+			return nil, errors.Wrap(err,
+				"Wildcard expression resulted in failed regular expression")
+		}
+		regexes = append(regexes, regex)
+	}
+
+	matches := []string{}
+	for _, attribute := range attributes {
+		for _, regex := range regexes {
+			if regex.MatchString(attribute) {
+				matches = append(matches, attribute)
+				break
+			}
+		}
+	}
+
+	return matches, nil
+}

--- a/utils/attributes_test.go
+++ b/utils/attributes_test.go
@@ -1,0 +1,133 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringsMatchingWildcards(t *testing.T) {
+	testCases := []struct {
+		provides []string
+		clearsProvides []string
+		expected []string
+	}{
+		{
+			provides: []string{
+				"rootfs-image.version",
+			},
+			clearsProvides: []string{
+				"rootfs-image.*",
+			},
+			expected: []string{
+				"rootfs-image.version",
+			},
+		},
+		{
+			provides: []string{
+				"rootfs-image.version",
+				"rootfs-image.single-file.version",
+			},
+			clearsProvides: []string{
+				"rootfs-image.*",
+			},
+			expected: []string{
+				"rootfs-image.version",
+				"rootfs-image.single-file.version",
+			},
+		},
+		{
+			provides: []string{
+				"rootfs-image.v",
+				"rootfs-image.version",
+				"rootfs-image.single-file.version",
+			},
+			clearsProvides: []string{
+				"rootfs-image.",
+			},
+			expected: []string{},
+		},
+		{
+			provides: []string{
+				"rootfs-image.version",
+				"rootfs-image.single-file.version",
+			},
+			clearsProvides: []string{},
+			expected: []string{},
+		},
+		{
+			provides: []string{
+				"rootfs-image.version",
+				"rootfs-image.single-file.version",
+			},
+			clearsProvides: nil,
+			expected: []string{},
+		},
+		{
+			provides: []string{
+				"rootfs-image.version",
+				"rootfs-image.single-file.version",
+			},
+			clearsProvides: []string{
+				"rootfs-image.version",
+			},
+			expected: []string{
+				"rootfs-image.version",
+			},
+		},
+		{
+			provides: []string{},
+			clearsProvides: []string{
+				"rootfs-image.version",
+			},
+			expected: []string{},
+		},
+		{
+			provides: nil,
+			clearsProvides: []string{
+				"rootfs-image.version",
+			},
+			expected: []string{},
+		},
+		{
+			provides: []string{
+				"rootfs-image.*",
+				"rootfs-image.version",
+			},
+			clearsProvides: []string{
+				"rootfs-image.\\*",
+			},
+			expected: []string{
+				"rootfs-image.*",
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(fmt.Sprintf("Test case %d", n), func(t *testing.T) {
+			result, err := StringsMatchingWildcards(tc.provides, tc.clearsProvides)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestStringsMatchingWildcardsError(t *testing.T) {
+	_, err := StringsMatchingWildcards(nil, []string{"\\"})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This is implemented in mender-artifact so that the deployments backend
can use the same function as the client to calculate the effect on
provides values for a multi-stage upgrade path, should we ever
implement that.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>