### PR TITLE
Add the ability to choose a string separator for dump print-cmdline

### DIFF
--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -543,6 +543,10 @@ func getCliContext() *cli.App {
 			Name:  "print-cmdline",
 			Usage: "Print the command line that can recreate the same Artifact with the components being dumped. If all the components are being dumped, a nearly identical Artifact can be created. Note that timestamps will cause the checksum of the Artifact to be different, and signatures can not be recreated this way. The command line will only use long option names.",
 		},
+		cli.BoolFlag{
+			Name:  "print0-cmdline",
+			Usage: "Same as 'print-cmdline', except that the arguments are separated by a null character (0x00).",
+		},
 	}
 
 	globalFlags := []cli.Flag{


### PR DESCRIPTION
This adds a flag 'separator', which can be set, in addition to print-cmdline,
which picks the separator to use for the output from the commmand.

The default is <space>.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>