### PR TITLE
MEN-3483: Add `--print0-cmdline` argument to `dump` command.

### DIFF
--- a/cli/mender-artifact/dump.go
+++ b/cli/mender-artifact/dump.go
@@ -90,8 +90,12 @@ func DumpCommand(c *cli.Context) error {
 		return err
 	}
 
-	if c.Bool("print-cmdline") {
-		printCmdline(ar, dumpArgs)
+	if c.Bool("print-cmdline") && c.Bool("print0-cmdline") {
+		return errors.New("--print-cmdline and --print0-cmdline are conflicting options.")
+	} else if c.Bool("print-cmdline") {
+		printCmdline(ar, dumpArgs, ' ', '\n')
+	} else if c.Bool("print0-cmdline") {
+		printCmdline(ar, dumpArgs, 0, 0)
 	}
 
 	return nil
@@ -178,67 +182,71 @@ func dumpMetaData(metaDataDir string, dumpArgs *[]string, handlers map[int]handl
 	return nil
 }
 
-func printCmdline(ar *areader.Reader, args []string) {
+func printCmdline(ar *areader.Reader, args []string, sep, endChar rune) {
 	// Even if it is a rootfs payload, we use the module-image writer, since
 	// this can recreate either type.
-	fmt.Printf("write module-image")
+	fmt.Printf("write%cmodule-image", sep)
 
 	if ar.GetInfo().Version == 3 {
 		artProvs := ar.GetArtifactProvides()
-		fmt.Printf(" --artifact-name %s", artProvs.ArtifactName)
+		fmt.Printf("%c--artifact-name%c%s", sep, sep, artProvs.ArtifactName)
 		if len(artProvs.ArtifactGroup) > 0 {
-			fmt.Printf(" --provides-group %s", artProvs.ArtifactGroup)
+			fmt.Printf("%c--provides-group%c%s", sep, sep, artProvs.ArtifactGroup)
 		}
 
 		artDeps := ar.GetArtifactDepends()
 		if len(artDeps.ArtifactName) > 0 {
-			fmt.Printf(" --artifact-name-depends %s", strings.Join(artDeps.ArtifactName, " --artifact-name-depends "))
+			fmt.Printf("%c--artifact-name-depends%c%s", sep, sep,
+				strings.Join(artDeps.ArtifactName, fmt.Sprintf("%c--artifact-name-depends%c", sep, sep)))
 		}
-		fmt.Printf(" --device-type %s", strings.Join(artDeps.CompatibleDevices, " --device-type "))
+		fmt.Printf("%c--device-type%c%s", sep, sep,
+			strings.Join(artDeps.CompatibleDevices, fmt.Sprintf("%c--device-type%c", sep, sep)))
 		if len(artDeps.ArtifactGroup) > 0 {
-			fmt.Printf(" --depends-groups %s", strings.Join(artDeps.ArtifactGroup, " --depends-groups "))
+			fmt.Printf("%c--depends-groups%c%s", sep, sep,
+				strings.Join(artDeps.ArtifactGroup, fmt.Sprintf("%c--depends-groups%c", sep, sep)))
 		}
 
 	} else if ar.GetInfo().Version == 2 {
-		fmt.Printf(" --artifact-name %s", ar.GetArtifactName())
-		fmt.Printf(" --device-type %s", strings.Join(ar.GetCompatibleDevices(), " --device-type "))
+		fmt.Printf("%c--artifact-name%c%s", sep, sep, ar.GetArtifactName())
+		fmt.Printf("%c--device-type%c%s", sep, sep, strings.Join(ar.GetCompatibleDevices(), " --device-type "))
 	}
 
 	handlers := ar.GetHandlers()
 	handler := handlers[0]
 
-	fmt.Printf(" --type %s", handler.GetUpdateType())
+	fmt.Printf("%c--type%c%s", sep, sep, handler.GetUpdateType())
 
 	// Always add this flag, since we will write custom flags.
-	fmt.Printf(" --%s", noDefaultSoftwareVersionFlag)
+	fmt.Printf("%c--%s", sep, noDefaultSoftwareVersionFlag)
 
 	provs := handler.GetUpdateOriginalProvides()
 	if provs != nil {
 		for key, value := range provs {
-			fmt.Printf(" --provides %s:%s", key, value)
+			fmt.Printf("%c--provides%c%s:%s", sep, sep, key, value)
 		}
 	}
 
 	deps := handler.GetUpdateOriginalDepends()
 	if deps != nil {
 		for key, value := range deps {
-			fmt.Printf(" --depends %s:%s", key, value)
+			fmt.Printf("%c--depends%c%s:%s", sep, sep, key, value)
 		}
 	}
 
 	// Always add this flag, since we will write custom flags.
-	fmt.Printf(" --%s", noDefaultClearsProvidesFlag)
+	fmt.Printf("%c--%s", sep, noDefaultClearsProvidesFlag)
 
 	caps := handler.GetUpdateOriginalClearsProvides()
 	if caps != nil {
 		for _, value := range caps {
-			fmt.Printf(" --%s '%s'", clearsProvidesFlag, value)
+			fmt.Printf("%c--%s%c%s", sep, clearsProvidesFlag, sep, value)
 		}
 	}
 
 	if len(args) > 0 {
-		fmt.Printf(" %s\n", strings.Join(args, " "))
+		fmt.Printf("%c%s", sep, strings.Join(args, string(sep)))
 	}
+	fmt.Printf("%c", endChar)
 }
 
 func (d *dumpFileStore) NewUpdateStorer(updateType string, payloadNum int) (handlers.UpdateStorer, error) {

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -543,6 +543,10 @@ func getCliContext() *cli.App {
 			Name:  "print-cmdline",
 			Usage: "Print the command line that can recreate the same Artifact with the components being dumped. If all the components are being dumped, a nearly identical Artifact can be created. Note that timestamps will cause the checksum of the Artifact to be different, and signatures can not be recreated this way. The command line will only use long option names.",
 		},
+		cli.BoolFlag{
+			Name:  "print0-cmdline",
+			Usage: "Same as 'print-cmdline', except that the arguments are separated by a null character (0x00).",
+		},
 	}
 
 	globalFlags := []cli.Flag{


### PR DESCRIPTION
Works exactly like `--print-cmdline` but prints null bytes between
arguments instead of spaces. This mirrors the `-print0` argument of
find and complements the `-0` argument of xargs.

Changelog: Commit
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>