### PR TITLE
MEN-3987 use sudo for snapshots if present.

### DIFF
--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -520,8 +520,9 @@ func getDeviceSnapshot(c *cli.Context) (string, error) {
 	// First echo to stdout such that we know when ssh connection is
 	// established (password prompt is written to /dev/tty directly,
 	// and hence impossible to detect).
-	args = append(args, "sudo", "-S", "/bin/sh", "-c",
-		`'echo "`+sshInitMagic+`" && mender snapshot dump | cat'`)
+	// When user id is 0 do not bother with sudo.
+	args = append(args, "/bin/sh", "-c",
+		`'[ $(id -u) -eq 0 ] || sudo_cmd="sudo -S"; $sudo_cmd /bin/sh -c "echo `+sshInitMagic+`; mender snapshot dump" | cat'`)
 
 	cmd := exec.Command("ssh", args...)
 


### PR DESCRIPTION
Changes to sudo usage for snapshots; use sudo only if:

* sudo is present and works
* user is not root

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>