### PR TITLE
Debug option to mender-artifact cli

### DIFF
--- a/artifact/checksum.go
+++ b/artifact/checksum.go
@@ -16,7 +16,6 @@ package artifact
 
 import (
 	"bytes"
-	"github.com/minio/sha256-simd"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -25,6 +24,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/minio/sha256-simd"
 	"github.com/pkg/errors"
 )
 

--- a/artifact/compressor_gzip_test.go
+++ b/artifact/compressor_gzip_test.go
@@ -43,7 +43,7 @@ func TestCompressorGzip(t *testing.T) {
 	assert.Equal(t, i, len(testData))
 	// It is perfectly valid for a reader to return nil on an exhaustive
 	// write when n-bytes read > 0
-	assert.True(t, err == io.EOF  || err == nil)
+	assert.True(t, err == io.EOF || err == nil)
 	assert.Equal(t, []byte(testData), rbuf)
 
 	// Second read must return zero bytes, and EOF though

--- a/artifact/signer.go
+++ b/artifact/signer.go
@@ -19,12 +19,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/minio/sha256-simd"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
 	"math/big"
 
+	"github.com/minio/sha256-simd"
 	"github.com/pkg/errors"
 )
 

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -70,6 +70,11 @@ func getCliContext() *cli.App {
 
 	app.EnableBashCompletion = true
 
+	debugFlag := cli.BoolFlag{
+		Name:  "debug, e",
+		Usage: "Enable debug output.",
+	}
+
 	compressors := artifact.GetRegisteredCompressorIds()
 
 	compressionFlag := cli.StringFlag{
@@ -142,6 +147,7 @@ func getCliContext() *cli.App {
 	writeRootfsCommand.CustomHelpTemplate = CustomSubcommandHelpTemplate
 
 	writeRootfsCommand.Flags = []cli.Flag{
+		debugFlag,
 		cli.StringFlag{
 			Name: "file, f",
 			Usage: "Payload `FILE` path or ssh-url to device for system " +

--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mendersoftware/mender-artifact/cli/mender-artifact/util"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"io"
 	"io/ioutil"
@@ -85,6 +86,10 @@ func validateInput(c *cli.Context) error {
 }
 
 func writeRootfs(c *cli.Context) error {
+	if c.Bool("debug") {
+		Log.SetLevel(logrus.DebugLevel)
+	}
+
 	comp, err := artifact.NewCompressorFromId(c.GlobalString("compression"))
 	if err != nil {
 		return cli.NewExitError("compressor '"+c.GlobalString("compression")+"' is not supported: "+err.Error(), 1)
@@ -366,6 +371,10 @@ func makeMetaData(ctx *cli.Context) (map[string]interface{}, map[string]interfac
 }
 
 func writeModuleImage(ctx *cli.Context) error {
+	if ctx.Bool("debug") {
+		Log.SetLevel(logrus.DebugLevel)
+	}
+
 	comp, err := artifact.NewCompressorFromId(ctx.GlobalString("compression"))
 	if err != nil {
 		return cli.NewExitError("compressor '"+ctx.GlobalString("compression")+"' is not supported: "+err.Error(), 1)


### PR DESCRIPTION
Support for --debug:

```bash
#./mender-artifact write rootfs-image -f ssh://xxxx -n pi -o snapshot-release.1.0.mender -t rpi4 --debug
debug: creating artifact [snapshot-release.1.0.mender], version: 3
................................   0% 1024 KiB
```

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>