### PR TITLE
Fix writing of corrupt Artifact: type-info is missing type for rootfs…

### DIFF
--- a/cli/mender-artifact/write.go
+++ b/cli/mender-artifact/write.go
@@ -200,7 +200,7 @@ func writeRootfs(c *cli.Context) error {
 		ArtifactGroup: c.String("provides-group"),
 	}
 
-	typeInfoV3, _, err := makeTypeInfo(c)
+	typeInfoV3, _, err := makeTypeInfo(c, "rootfs-image")
 	if err != nil {
 		return err
 	}
@@ -323,7 +323,7 @@ func makeUpdates(ctx *cli.Context) (*awriter.Updates, error) {
 
 // makeTypeInfo returns the type-info provides and depends and the augmented
 // type-info provides and depends, or nil.
-func makeTypeInfo(ctx *cli.Context) (*artifact.TypeInfoV3, *artifact.TypeInfoV3, error) {
+func makeTypeInfo(ctx *cli.Context, typ string) (*artifact.TypeInfoV3, *artifact.TypeInfoV3, error) {
 	// Make key value pairs from the type-info fields supplied on command
 	// line.
 	var keyValues *map[string]string
@@ -375,7 +375,7 @@ func makeTypeInfo(ctx *cli.Context) (*artifact.TypeInfoV3, *artifact.TypeInfoV3,
 	}
 
 	typeInfoV3 := &artifact.TypeInfoV3{
-		Type:                   ctx.String("type"),
+		Type:                   typ,
 		ArtifactDepends:        typeInfoDepends,
 		ArtifactProvides:       typeInfoProvides,
 		ClearsArtifactProvides: clearsArtifactProvides,
@@ -621,7 +621,7 @@ func writeModuleImage(ctx *cli.Context) error {
 		ArtifactGroup: ctx.String("provides-group"),
 	}
 
-	typeInfoV3, augmentTypeInfoV3, err := makeTypeInfo(ctx)
+	typeInfoV3, augmentTypeInfoV3, err := makeTypeInfo(ctx, ctx.String("type"))
 	if err != nil {
 		return err
 	}

--- a/handlers/module_image.go
+++ b/handlers/module_image.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -458,6 +458,12 @@ func (img *ModuleImage) ReadHeader(r io.Reader, path string, version int, augmen
 		err := dec.Decode(&img.typeInfoV3)
 		if err != nil {
 			return errors.Wrap(err, "error reading type-info")
+		}
+		if img.typeInfoV3 == nil || img.typeInfoV3.Type != img.updateType {
+			return errors.New("Type in type-info header does not match header-info: " +
+				"Corrupt Artifact. " +
+				"This was a known bug in some versions of mender-artifact prior to 3.5.1. " +
+				"Please recreate the artifact with version 3.5.1 or newer.")
 		}
 	case filepath.Base(path) == "meta-data":
 		dec := json.NewDecoder(r)

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -127,6 +127,12 @@ func (rp *Rootfs) ReadHeader(r io.Reader, path string, version int, augmented bo
 		err := dec.Decode(&rp.typeInfoV3)
 		if err != nil {
 			return errors.Wrap(err, "error reading type-info")
+		}
+		if rp.typeInfoV3 == nil || rp.typeInfoV3.Type != "rootfs-image" {
+			return errors.New("Type in type-info header does not match header-info: " +
+				"Corrupt Artifact. " +
+				"This was a known bug in some versions of mender-artifact prior to 3.5.1. " +
+				"Please recreate the artifact with version 3.5.1 or newer.")
 		}
 
 	case filepath.Base(path) == "meta-data":


### PR DESCRIPTION
…-image.

Changelog: Fix regression which caused the "write rootfs-image"
command to produce a corrupt Artifact. The same versions that write
such an Artifact will also accept it, but both issues have been fixed:
A corrupt Artifact is not written anymore, nor will corrupt Artifacts
be accepted. If you have produced an Artifact using a version of
mender-artifact prior to 3.5.1, you may have to recreate it.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>