### PR TITLE
MEN-4502: Do not change the underlying Artifact unnecessarily

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ type Reader struct {
 	manifest        *artifact.ChecksumStore
 	menderTarReader *tar.Reader
 	ProgressReader  ProgressReader
+	compressor      artifact.Compressor
 }
 
 func NewReader(r io.Reader) *Reader {
@@ -419,6 +420,7 @@ func (ar *Reader) handleHeaderReads(headerName string, version []byte) error {
 		if err != nil {
 			return errors.New("reader: can't get compressor")
 		}
+		ar.compressor = comp
 
 		if err := ar.readHeader(hc, comp); err != nil {
 			return errors.Wrap(err, "handleHeaderReads")
@@ -532,6 +534,7 @@ func (ar *Reader) readHeaderV2(version []byte) error {
 		if err != nil {
 			return errors.New("reader: can't get compressor")
 		}
+		ar.compressor = comp
 
 		if err := ar.readHeader(hc, comp); err != nil {
 			return err
@@ -1134,4 +1137,8 @@ func (ar *Reader) MergeArtifactClearsProvides() []string {
 		list = append(list, inst.GetUpdateClearsProvides()...)
 	}
 	return list
+}
+
+func (ar *Reader) Compressor() artifact.Compressor {
+	return ar.compressor
 }

--- a/cli/mender-artifact/artifacts.go
+++ b/cli/mender-artifact/artifacts.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/mendersoftware/mender-artifact/areader"
-	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/mendersoftware/mender-artifact/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,7 +288,6 @@ func TestCopyRootfsImage(t *testing.T) {
 			},
 			argv: []string{"mender-artifact", "install", "-m", "0600", "testkey", "<artifact|sdimg|fat-sdimg>:/etc/mender/testkey.key"},
 			verifyTestFunc: func(imgpath string) {
-				comp := artifact.NewCompressorGzip()
 				cmd := exec.Command(filepath.Join(dir, "mender-artifact"), "cat", imgpath+":/etc/mender/testkey.key")
 				var out bytes.Buffer
 				cmd.Stdout = &out
@@ -299,7 +297,7 @@ func TestCopyRootfsImage(t *testing.T) {
 				// Cleanup the testkey
 				assert.Nil(t, os.Remove("testkey"))
 				// Check that the permission bits have been set correctly!
-				pf, err := virtualImage.OpenFile(comp, nil, imgpath+":/etc/mender/testkey.key")
+				pf, err := virtualImage.OpenFile(nil, imgpath+":/etc/mender/testkey.key")
 				defer pf.Close()
 				require.Nil(t, err)
 				// Type switch on the artifact, or sdimg underlying
@@ -330,7 +328,6 @@ func TestCopyRootfsImage(t *testing.T) {
 			},
 			argv: []string{"mender-artifact", "install", "-m", "0777", "testkey", "<artifact|sdimg|fat-sdimg>:/etc/mender/testkey.key"},
 			verifyTestFunc: func(imgpath string) {
-				comp := artifact.NewCompressorGzip()
 				cmd := exec.Command(filepath.Join(dir, "mender-artifact"), "cat", imgpath+":/etc/mender/testkey.key")
 				var out bytes.Buffer
 				cmd.Stdout = &out
@@ -340,7 +337,7 @@ func TestCopyRootfsImage(t *testing.T) {
 				// Cleanup the testkey
 				assert.Nil(t, os.Remove("testkey"))
 				// Check that the permission bits have been set correctly!
-				pf, err := virtualImage.OpenFile(comp, nil, imgpath+":/etc/mender/testkey.key")
+				pf, err := virtualImage.OpenFile(nil, imgpath+":/etc/mender/testkey.key")
 				defer pf.Close()
 				require.Nil(t, err)
 				// Type switch on the artifact, or sdimg underlying
@@ -371,7 +368,6 @@ func TestCopyRootfsImage(t *testing.T) {
 			},
 			argv: []string{"mender-artifact", "install", "-m", "0700", "testkey", "<artifact|sdimg|fat-sdimg>:/etc/mender/testkey.key"},
 			verifyTestFunc: func(imgpath string) {
-				comp := artifact.NewCompressorGzip()
 				cmd := exec.Command(filepath.Join(dir, "mender-artifact"), "cat", imgpath+":/etc/mender/testkey.key")
 				var out bytes.Buffer
 				cmd.Stdout = &out
@@ -381,7 +377,7 @@ func TestCopyRootfsImage(t *testing.T) {
 				// Cleanup the testkey
 				assert.Nil(t, os.Remove("testkey"))
 				// Check that the permission bits have been set correctly!
-				pf, err := virtualImage.OpenFile(comp, nil, imgpath+":/etc/mender/testkey.key")
+				pf, err := virtualImage.OpenFile(nil, imgpath+":/etc/mender/testkey.key")
 				defer pf.Close()
 				require.Nil(t, err)
 				// Type switch on the artifact, or sdimg underlying
@@ -606,8 +602,7 @@ func TestCopyRootfsImage(t *testing.T) {
 			argv: []string{"mender-artifact", "cp", "foobar.txt", "<artifact|sdimg|fat-sdimg>:/etc/mender/foo.txt"},
 			verifyTestFunc: func(imgpath string) {
 				defer os.Remove("foobar.txt")
-				comp := artifact.NewCompressorGzip()
-				pf, err := virtualImage.OpenFile(comp, nil, imgpath+":/etc/mender/foo.txt")
+				pf, err := virtualImage.OpenFile(nil, imgpath+":/etc/mender/foo.txt")
 				defer pf.Close()
 				require.Nil(t, err)
 				// Type switch on the artifact, or sdimg underlying

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -59,6 +59,38 @@ func main() {
 	}
 }
 
+// Copied from urfave/cli/template.go
+// with the addition of the NOTE on the `global` `--compression flag`
+var menderAppHelpTemplate = `NAME:
+   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if len .Authors}}
+
+AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
+   {{range $index, $author := .Authors}}{{if $index}}
+   {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+GLOBAL OPTIONS:
+   {{range $index, $option := .VisibleFlags}}{{if $index}}
+   {{end}}{{$option}}{{end}}{{end}}
+   NOTE:
+       For the commands <write>, <modify>, the '--compression' flag functions as
+       a global option
+`
+
 func applyCompressionInCommand(c *cli.Context) error {
 	// Let --compression argument work after command as well. Latest one
 	// applies.
@@ -90,6 +122,7 @@ func getCliContext() *cli.App {
 	globalCompressionFlag := compressionFlag
 	// The global flag is the last fallback, so here we provide a default.
 	globalCompressionFlag.Value = "gzip"
+	globalCompressionFlag.Hidden = true
 
 	privateKeyFlag := cli.StringFlag{
 		Name: "key, k",
@@ -581,6 +614,7 @@ func getCliContext() *cli.App {
 		sortFlags(cmd)
 	}
 
+	app.CustomAppHelpTemplate = menderAppHelpTemplate
 	return app
 }
 

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -482,7 +482,6 @@ func getCliContext() *cli.App {
 		compressionFlag,
 		privateKeyFlag,
 	}
-	copy.Before = applyCompressionInCommand
 
 	cat := cli.Command{
 		Name:        "cat",

--- a/cli/mender-artifact/modify.go
+++ b/cli/mender-artifact/modify.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -46,7 +46,12 @@ func modifyArtifact(c *cli.Context) (err error) {
 		return cli.NewExitError("File ["+c.Args().First()+"] does not exist.", 1)
 	}
 
-	image, err := virtualImage.Open(comp, privateKey, c.Args().First())
+	var image VPImage
+	if c.String("compression") != "" {
+		image, err = virtualImage.Open(privateKey, c.Args().First(), comp)
+	} else {
+		image, err = virtualImage.Open(privateKey, c.Args().First())
+	}
 
 	if err != nil {
 		return cli.NewExitError("Error selecting images for modification: "+err.Error(), 1)
@@ -62,6 +67,7 @@ func modifyArtifact(c *cli.Context) (err error) {
 		}
 	}()
 
+	image.dirtyImage()
 	if err := modifyExisting(c, image); err != nil {
 		return cli.NewExitError("Error modifying artifact["+c.Args().First()+"]: "+
 			err.Error(), 1)

--- a/cli/mender-artifact/modify_existing_test.go
+++ b/cli/mender-artifact/modify_existing_test.go
@@ -109,7 +109,7 @@ func verify(image, file, expected string) bool {
 
 func verifySDImg(image, file, expected string) bool {
 
-	part, err := virtualImage.Open(nil, nil, image)
+	part, err := virtualImage.Open(nil, image)
 
 	if err != nil {
 		return false


### PR DESCRIPTION
Fixes the issue where modifying an artifact by any of the utility commands would change the compression to `gzip`, as the Artifact was always repacked with the standard compression. This would also destroy signed Artifacts using commands such as `cat` which should have no effect on the signature.

This led to the discovery along the way, that most commands did indeed not respect the `compression` flag - which claimed to be global in scope. Therefore, this removes the global claim from the helptext, and instead adds a note about the `compression` flag's functionality, which after all, if you read the note, was limited to only a few commands in scope.

I guess most people never used the `compression` flag with most of the utility commands (as it would not have worked). Therefore I feel these changes are safe. 

The warning added tells the user to use  the `<modify>` command to change the `compression` type of an image/Artifact. Which I feel is, and should have been, the right approach all along.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>