### PR TITLE
[copy_test] Amend tests to always call verifyTestFunc

### DIFF
--- a/cli/mender-artifact/copy_test.go
+++ b/cli/mender-artifact/copy_test.go
@@ -791,20 +791,14 @@ func TestCopyRootfsImage(t *testing.T) {
 
 					if test.err != "" {
 						assert.Contains(t, err.Error(), test.err)
-						return
+					} else if err != nil {
+						t.Log(out)
+						t.Fatal(fmt.Sprintf("cmd: %s failed with err: %v", test.name, err))
 					}
 
-					if err != nil {
-						if test.err != "" {
-							assert.Contains(t, err.Error(), test.err, test.name)
-						} else {
-							t.Log(out)
-							t.Fatal(fmt.Sprintf("cmd: %s failed with err: %v", test.name, err))
-						}
-					}
 					if test.verifyTestFunc != nil {
 						test.verifyTestFunc(targ.validImg)
-					} else {
+					} else if test.err == "" {
 						assert.Equal(t, test.expected, out, test.name)
 					}
 				})


### PR DESCRIPTION
This function is also used in most test case to clean-up temp files, so
remove the early return on test cases expecting error, so that we call
such function for all.

Introduced at a4bf948c.