### PR TITLE
Misc minor user facing nit-picks

### DIFF
--- a/artifact/scripter.go
+++ b/artifact/scripter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ func (s *Scripts) Add(path string) error {
 	// the second one shold be the name of the state
 	matches := re.FindStringSubmatch(name)
 	if matches == nil || len(matches) < 3 {
-		return errors.Errorf("scripter: invalid script: %s", name)
+		return errors.Errorf("scripter: invalid script name: %q. Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.", name)
 	}
 	if _, found := availableScriptType[matches[1]]; !found {
 		return errors.Errorf("scripter: unsupported script state: %s", matches[1])

--- a/artifact/scripter.go
+++ b/artifact/scripter.go
@@ -54,14 +54,14 @@ func (s *Scripts) Add(path string) error {
 	// the second one shold be the name of the state
 	matches := re.FindStringSubmatch(name)
 	if matches == nil || len(matches) < 3 {
-		return errors.Errorf("scripter: invalid script name: %q. Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.", name)
+		return errors.Errorf("Invalid script name: %q. Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.", name)
 	}
 	if _, found := availableScriptType[matches[1]]; !found {
-		return errors.Errorf("scripter: unsupported script state: %s", matches[1])
+		return errors.Errorf("Unsupported script state: %s", matches[1])
 	}
 
 	if _, exists := s.names[name]; exists {
-		return errors.Errorf("scripter: script already exists: %s", name)
+		return errors.Errorf("Script already exists: %s", name)
 	}
 
 	s.names[name] = path

--- a/artifact/scripter_test.go
+++ b/artifact/scripter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -41,23 +41,23 @@ func TestAdding(t *testing.T) {
 	// script already exists
 	err = s.Add(`ArtifactCommit_Enter_11`)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "script already exists")
+	assert.Contains(t, err.Error(), "Script already exists")
 	assert.Len(t, s.names, 3)
 
 	// non existing state
 	err = s.Add(`InvalidState_Enter_10`)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported script state")
+	assert.Contains(t, err.Error(), "Unsupported script state")
 	assert.Len(t, s.names, 3)
 
 	// bad formatting
 	err = s.Add(`ArtifactCommit_Bad_10`)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid script")
+	assert.Contains(t, err.Error(), "Invalid script")
 	assert.Len(t, s.names, 3)
 
 	err = s.Add(`ArtifactCommit_Enter`)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid script")
+	assert.Contains(t, err.Error(), "Invalid script")
 	assert.Len(t, s.names, 3)
 }

--- a/cli/mender-artifact/main.go
+++ b/cli/mender-artifact/main.go
@@ -432,7 +432,7 @@ func getCliContext() *cli.App {
 		cli.StringFlag{
 			Name: "output-path, o",
 			Usage: "Full path to output signed artifact file; " +
-				"if none is provided existing artifact will be replaced with signed one",
+				"if none is provided existing artifact will be replaced with the signed one",
 		},
 		cli.BoolFlag{
 			Name:  "force, f",

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -166,7 +166,7 @@ func TestWithScripts(t *testing.T) {
 	fakeErrWriter.Reset()
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "scripter: invalid script name: \"InvalidScript\". Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.\n",
+	assert.Equal(t, "Invalid script name: \"InvalidScript\". Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.\n",
 		fakeErrWriter.String())
 }
 

--- a/cli/mender-artifact/write_test.go
+++ b/cli/mender-artifact/write_test.go
@@ -166,7 +166,7 @@ func TestWithScripts(t *testing.T) {
 	fakeErrWriter.Reset()
 	err = run()
 	assert.Error(t, err)
-	assert.Equal(t, "scripter: invalid script: InvalidScript\n",
+	assert.Equal(t, "scripter: invalid script name: \"InvalidScript\". Scripts must have a name on the form: <STATE_NAME>_<ACTION>_<ORDERING_NUMBER>_<OPTIONAL_DESCRIPTION>. For example: 'Download_Enter_05_wifi-driver' is a valid script name.\n",
 		fakeErrWriter.String())
 }
 


### PR DESCRIPTION
Notably:
* Improve the error message when adding a state script with a wrong naming scheme
* Add a missing article in the description of the output-path CLI description