### PR TITLE
[MEN-4832] Fix sending on closed signal channel

### DIFF
--- a/cli/util/tty_windows.go
+++ b/cli/util/tty_windows.go
@@ -17,6 +17,7 @@
 package util
 
 import (
+	"context"
 	"os"
 	"os/signal"
 
@@ -48,16 +49,28 @@ func DisableEcho(fd int) (uint32, error) {
 // Signal handler to re-enable tty echo on interrupt. os/signal only
 // handles ^C or ^BREAK events to the terminal, thus the signal won't be
 // relayed to the OS handler for this case.
-func EchoSigHandler(sigChan chan os.Signal, errChan chan error,
+func EchoSigHandler(ctx context.Context, sigChan chan os.Signal, errChan chan error,
 	cmode uint32) {
-	sig, sigRecved := <-sigChan
-	// Enable console echo (restore cmode)
-	windows.SetConsoleMode(windows.Handle(int(os.Stdin.Fd())), cmode)
-	if sigRecved {
-		signal.Stop(sigChan)
-		errChan <- errors.Errorf("Received signal: %s",
-			sig.String())
-	} else {
-		errChan <- nil
+	for {
+		var (
+			sig       os.Signal
+			sigRecved bool
+		)
+		select {
+		case <-ctx.Done():
+			errChan <- nil
+			return
+		case sig, sigRecved = <-sigChan:
+		}
+		// Enable console echo (restore cmode)
+		windows.SetConsoleMode(windows.Handle(int(os.Stdin.Fd())), cmode)
+		if sigRecved {
+			signal.Stop(sigChan)
+			errChan <- errors.Errorf("Received signal: %s",
+				sig.String())
+		} else {
+			errChan <- nil
+			return
+		}
 	}
 }

--- a/cli/write.go
+++ b/cli/write.go
@@ -683,6 +683,8 @@ func getDeviceSnapshot(c *cli.Context) (string, error) {
 	var userAtHost string
 	var sigChan chan os.Signal
 	var errChan chan error
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	port := "22"
 	host := strings.TrimPrefix(c.String("file"), "ssh://")
 
@@ -737,13 +739,12 @@ func getDeviceSnapshot(c *cli.Context) (string, error) {
 	// Disable tty echo before starting
 	term, err := util.DisableEcho(int(os.Stdin.Fd()))
 	if err == nil {
-		sigChan = make(chan os.Signal)
-		errChan = make(chan error)
-		defer closeSigChanIfOpen(sigChan)
+		sigChan = make(chan os.Signal, 1)
+		errChan = make(chan error, 1)
 		// Make sure that echo is enabled if the process gets
 		// interrupted
 		signal.Notify(sigChan)
-		go util.EchoSigHandler(sigChan, errChan, term)
+		go util.EchoSigHandler(ctx, sigChan, errChan, term)
 	} else if err != syscall.ENOTTY {
 		return "", err
 	}
@@ -778,7 +779,7 @@ func getDeviceSnapshot(c *cli.Context) (string, error) {
 	if sigChan != nil {
 		// Wait for signal handler to execute
 		signal.Stop(sigChan)
-		close(sigChan)
+		cancel()
 		err = <-errChan
 	}
 
@@ -877,22 +878,5 @@ func removeOnPanic(filename string) {
 			}
 		}
 		panic(r)
-	}
-}
-
-func closeSigChanIfOpen(sigChan chan os.Signal) {
-	// Close sigChan only if still open
-	if sigChan != nil {
-		select {
-		case _, open := <-sigChan:
-			if open {
-				signal.Stop(sigChan)
-				close(sigChan)
-			}
-		default:
-			// No data ready on sigChan
-			signal.Stop(sigChan)
-			close(sigChan)
-		}
 	}
 }


### PR DESCRIPTION
There is a [potential race condition](https://golang.org/src/os/signal/signal.go#L199)
where signals sent right before or while signal.Stop is closed does not
reach the signal channel until after the function returns. In such cases
it can happen that the signal channel is closed before the signal has
been propagated to the handler. This commit instead of closing the
signal channel, uses a separate channel (context.WithCancel) to stop
listening for signals after calling signal.Stop.

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>