### PR TITLE
3.5.x: [MEN-4832] Fix sending on closed signal channel

### DIFF
--- a/cli/mender-artifact/util/tty.go
+++ b/cli/mender-artifact/util/tty.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package util
 
 import (
+	"context"
 	"os"
-	"os/signal"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -43,14 +43,23 @@ func DisableEcho(fd int) (*unix.Termios, error) {
 
 // Signal handler to re-enable tty echo on interrupt. The signal handler is
 // transparent with system default, and immedeately releases the channel and
-// calling the system sighandler after termios is set. To invoke it manually,
-// simply close the sigChan (make sure to call signal.Stop prior to closing).
+// calling the system sighandler after termios is set.
 func EchoSigHandler(
+	ctx context.Context,
 	sigChan chan os.Signal,
 	errChan chan error,
 	term *unix.Termios) {
 	for {
-		sig, sigRecved := <-sigChan
+		var (
+			sig       os.Signal
+			sigRecved bool
+		)
+		select {
+		case <-ctx.Done():
+			errChan <- nil
+			return
+		case sig, sigRecved = <-sigChan:
+		}
 		if sig == unix.SIGWINCH || sig == unix.SIGURG {
 			// Though SIGCHLD is ignored by default, in this context
 			// we want to restore echo state.
@@ -59,7 +68,6 @@ func EchoSigHandler(
 		// Restore Termios
 		unix.IoctlSetTermios(int(os.Stdin.Fd()), ioctlSetTermios, term)
 		if sigRecved {
-			signal.Stop(sigChan)
 			switch sig {
 			case unix.SIGCHLD:
 				// SIGCHLD is expected when ssh terminates.
@@ -72,7 +80,7 @@ func EchoSigHandler(
 			}
 		} else {
 			errChan <- nil
+			return
 		}
-		break
 	}
 }


### PR DESCRIPTION
There is a [potential race condition](https://golang.org/src/os/signal/signal.go#L199)
where signals sent right before or while signal.Stop is closed does not
reach the signal channel until after the function returns. In such cases
it can happen that the signal channel is closed before the signal has
been propagated to the handler. This commit instead of closing the
signal channel, uses a separate channel (context.WithCancel) to stop
listening for signals after calling signal.Stop.

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>
(cherry picked from commit 64a6fc49023649a5bd9df020ec97076844f33976)