### PR TITLE
Improve install targets in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,5 @@ RUN apt-get update && apt-get install -qyy liblzma-dev
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .
-RUN make build
-RUN make install
+RUN make goinstall
 ENTRYPOINT [ "/go/bin/mender-artifact" ]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ PREFIX ?= /usr/local
 PKGS = $(shell go list ./... | grep -v vendor)
 SUBPKGS = $(shell go list ./... | sed '1d' | tr '\n' ',' | sed 's/,$$//1')
 PKGNAME = mender-artifact
+GOEXE := $(shell $(GO) env GOEXE)
+FINALEXE = $(PKGNAME)$(GOEXE)
 PKGFILES = $(shell find . \( -path ./vendor -o -path ./Godeps \) -prune \
 		-o -type f -name '*.go' -print)
 PKGFILES_notest = $(shell echo $(PKGFILES) | tr ' ' '\n' | grep -v _test.go)
@@ -37,8 +39,8 @@ ifneq ($(TAGS),)
 BUILDTAGS = -tags '$(TAGS)'
 endif
 
-build:
-	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+build $(FINALEXE):
+	$(GO) build $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS) -o $(FINALEXE)
 
 PLATFORMS := darwin linux windows
 
@@ -68,8 +70,13 @@ build-natives-contained:
 	docker run --rm --entrypoint "/bin/sh" -v $(shell pwd):/binary $$image_id -c "cp /go/bin/mender-artifact* /binary" && \
 	docker image rm $$image_id
 
-install:
+goinstall:
 	@$(GO) install $(GO_LDFLAGS) $(BUILDV) $(BUILDTAGS)
+
+install-all: install install-autocomplete-scripts
+
+install: $(FINALEXE)
+	install -Dm0755 $(FINALEXE) $(DESTDIR)$(PREFIX)/bin/$(FINALEXE)
 
 install-autocomplete-scripts:
 	@echo "Installing Bash auto-complete script into $(DESTDIR)/etc/bash_completion.d/"
@@ -84,6 +91,7 @@ clean:
 	$(GO) clean
 	rm -f mender-artifact-darwin mender-artifact-linux mender-artifact-windows.exe
 	rm -f coverage.txt coverage-tmp.txt
+	rm -f $(FINALEXE)
 
 get-tools:
 	set -e ; for t in $(TOOLS); do \
@@ -141,4 +149,4 @@ coverage:
 
 .PHONY: build clean get-tools test check \
 	cover htmlcover coverage tooldep install-autocomplete-scripts \
-	instrument-binary
+	instrument-binary install-all install

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ goinstall:
 
 install-all: install install-autocomplete-scripts
 
-install: $(FINALEXE)
+install: build
 	install -Dm0755 $(FINALEXE) $(DESTDIR)$(PREFIX)/bin/$(FINALEXE)
 
 install-autocomplete-scripts:


### PR DESCRIPTION
This aims to improve a couple of shortcomings in the Makefile related to file installation system-wide (or packaging-wide) that I noticed while creating a Slackware package for this program. These are:

 - improper PREFIX variable usage, i.e. using `$(PREFIX)/usr/local` will create a `/usr/local/usr/local` or `/usr/usr/local` hierarchy depending on whether PREFIX is set to `/usr` or `/usr/local`, which is probably not desirable;
 - inconsistent use of braces instead of round brackets.

I also added a couple of lines in the README.md file to mention these adjustable parameters, but do tell me if that falls in the "too much information in the README" category.

I tested these changes by simply pointing to a DESTDIR directory under `/tmp` and checking that the files are indeed put in the expected paths:

```sh
$ ls -l /tmp/test
ls: cannot access '/tmp/test': No such file or directory
$ make DESTDIR=/tmp/test PREFIX=/usr install-autocomplete-scripts
Installing Bash auto-complete script into /tmp/test/etc/bash_completion.d/
Installing zsh auto-complete script into /tmp/test/usr/share/zsh/site-functions/
$ tree /tmp/test/
/tmp/test/
├── etc
│   └── bash_completion.d
│       └── mender-artifact
└── usr
    └── share
        └── zsh
            └── site-functions
                └── _mender-artifact

6 directories, 2 files
```

If you're okay with these changes, I'd also like to add the capability to the `install` target to install the binary directly in `$(DESTDIR)$(PREFIX)/bin` instead of the default `$GOPATH/bin`.
