### PR TITLE
[Cherry 3.5.x] MEN-5094: Empty the header reader before calculating the checksum

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -159,6 +159,10 @@ func (ar *Reader) readHeader(headerSum []byte, comp artifact.Compressor) error {
 		return err
 	}
 
+	// Empty the remaining reader
+	// See (MEN-5094)
+	io.Copy(ioutil.Discard, r)
+
 	// Check if header checksum is correct.
 	if cr, ok := r.(*artifact.Checksum); ok {
 		if err = cr.Verify(); err != nil {
@@ -219,6 +223,10 @@ func (ar *Reader) readAugmentedHeader(headerSum []byte, comp artifact.Compressor
 	if err = ar.readHeaderUpdate(tr, hdr, true); err != nil {
 		return errors.Wrap(err, "readAugmentedHeader")
 	}
+
+	// Empty the remaining reader
+	// See (MEN-5094)
+	io.Copy(ioutil.Discard, r)
 
 	// Check if header checksum is correct.
 	if cr, ok := r.(*artifact.Checksum); ok {


### PR DESCRIPTION
Changelog: Fix the checksum errors encountered in rare cases where the entire byte
stream is not consumed during verification, and thus giving wrong checksum errors.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 8d0fb66d5371936490923bed4a25e2d3fce30beb)
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>