### PR TITLE
3.6.x: MEN-5094: Empty the header reader before calculating the checksum

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -159,6 +159,10 @@ func (ar *Reader) readHeader(headerSum []byte, comp artifact.Compressor) error {
 		return err
 	}
 
+	// Empty the remaining reader
+	// See (MEN-5094)
+	io.Copy(ioutil.Discard, r)
+
 	// Check if header checksum is correct.
 	if cr, ok := r.(*artifact.Checksum); ok {
 		if err = cr.Verify(); err != nil {
@@ -219,6 +223,10 @@ func (ar *Reader) readAugmentedHeader(headerSum []byte, comp artifact.Compressor
 	if err = ar.readHeaderUpdate(tr, hdr, true); err != nil {
 		return errors.Wrap(err, "readAugmentedHeader")
 	}
+
+	// Empty the remaining reader
+	// See (MEN-5094)
+	io.Copy(ioutil.Discard, r)
 
 	// Check if header checksum is correct.
 	if cr, ok := r.(*artifact.Checksum); ok {


### PR DESCRIPTION
Porting #355.