### PR TITLE
MEN-5082: Restore SSH snapshot feature on Mac OS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,13 @@ build:make:
     paths:
       - mender-artifact-*
   tags:
-    - docker
+    - mender-qa-slave
+  variables:
+    # Docker dind configuration for mender-qa-slave
+    DOCKER_HOST: "tcp://docker:2376"
+    DOCKER_CERT_PATH: "/certs/client"
+    DOCKER_TLS_VERIFY: "1"
+    DOCKER_TLS_CERTDIR: "/certs"
 
 test:smoketests:mac:
   stage: test

--- a/cli/partition.go
+++ b/cli/partition.go
@@ -44,6 +44,7 @@ const (
 )
 
 var errFsTypeUnsupported = errors.New("mender-artifact can only modify ext4 and vfat payloads")
+var errBlkidNotFound = errors.New("`blkid` binary not found on the system")
 
 type VPImage interface {
 	io.Closer
@@ -367,7 +368,7 @@ func parseImgPath(imgpath string) (imgname, fpath string, err error) {
 func imgFilesystemType(imgpath string) (int, error) {
 	bin, err := utils.GetBinaryPath("blkid")
 	if err != nil {
-		return unsupported, fmt.Errorf("`blkid` binary not found on the system")
+		return unsupported, errBlkidNotFound
 	}
 	cmd := exec.Command(bin, "-s", "TYPE", imgpath)
 	buf := bytes.NewBuffer(nil)

--- a/cli/write.go
+++ b/cli/write.go
@@ -99,11 +99,17 @@ func createRootfsFromSSH(c *cli.Context) (string, error) {
 		return rootfsFilename, cli.NewExitError("SSH error: "+err.Error(), 1)
 	}
 
-	// run fsck
+	// check for blkid and get filesystem type
 	fstype, err := imgFilesystemType(rootfsFilename)
 	if err != nil {
+		if err == errBlkidNotFound {
+			Log.Warnf("Skipping running fsck on the Artifact: %v", err)
+			return rootfsFilename, nil
+		}
 		return rootfsFilename, cli.NewExitError("imgFilesystemType error: "+err.Error(), errArtifactCreate)
 	}
+
+	// run fsck
 	switch fstype {
 	case fat:
 		err = runFsck(rootfsFilename, "vfat")


### PR DESCRIPTION
While fixing MEN-4362, we introduced a dependency for the SSH snapshot
feature on `blkid`, in effect introducing a regression on Mac OS where
this tool is not present.

This commit amends 3457a15 converting it into a soft requirement: run
fsck only if supported, leaving otherwise the Artifact unaltered (which
the underlying risk that could be corrupted)

Changelog: Title