### PR TITLE
Fix: signing not working together with `module-image`.

### DIFF
--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -154,6 +154,7 @@ func getKey(c *cli.Context) (SigningKey, error) {
 		}
 		privateKeyCommands := map[string]bool{
 			"rootfs-image": true,
+			"module-image": true,
 			"sign":         true,
 			"modify":       true,
 			"copy":         true,


### PR DESCRIPTION
This affects all update module generators.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>