### PR TITLE
3.7.x: Fix: signing not working together with `module-image`.

### DIFF
--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -153,6 +153,7 @@ func getKey(c *cli.Context) (SigningKey, error) {
 		}
 		privateKeyCommands := map[string]bool{
 			"rootfs-image": true,
+			"module-image": true,
 			"sign":         true,
 			"modify":       true,
 			"copy":         true,


### PR DESCRIPTION
This affects all update module generators.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 0bc265e8a8c9b799465a58ae342f44ebbd757864)