### PR TITLE
statically linked linux binary

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,23 +29,6 @@ variables:
    S3_BUCKET_NAME: "mender"
    S3_BUCKET_PATH: "mender-artifact"
 
-
-build:docker:
-  image: docker
-  needs: []
-  services:
-    - docker:19.03.5-dind
-  stage: build
-  script:
-    - docker build -t $DOCKER_REPOSITORY:pr .
-    - docker save $DOCKER_REPOSITORY:pr > image.tar
-  artifacts:
-    expire_in: 2w
-    paths:
-      - image.tar
-  tags:
-    - docker
-
 build:make:
   image: docker
   needs: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM golang:1.14 as builder
-RUN apt-get update && apt-get install -qyy liblzma-dev
-RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
-WORKDIR /go/src/github.com/mendersoftware/mender-artifact
-ADD ./ .
-RUN make build
-RUN make install
-ENTRYPOINT [ "/go/bin/mender-artifact" ]

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -4,12 +4,11 @@ RUN apt-get update && \
         gcc gcc-mingw-w64 gcc-multilib \
         git make \
         musl-dev liblzma-dev
-RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .
 RUN make build-natives
 
-FROM alpine:3.15.0
-RUN apk add xz-dev
+FROM alpine:3.15
+RUN apk add --no-cache xz-dev
 COPY --from=builder /go/src/github.com/mendersoftware/mender-artifact/mender-artifact* /go/bin/
 ENTRYPOINT [ "/go/bin/mender-artifact-linux" ]

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,6 @@ build-natives:
 	@env GOOS=windows GOARCH=$$arch CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ \
 		$(GO) build $(GO_LDFLAGS_WIN) $(BUILDV) -tags $(TAGS) nolzma -o $(PKGNAME)-windows.exe ;
 
-build-contained:
-	rm -f mender-artifact && \
-	image_id=$$(docker build -f Dockerfile . | awk '/Successfully built/{print $$NF;}') && \
-	docker run --rm --entrypoint "/bin/sh" -v $(shell pwd):/binary $$image_id -c "cp /go/bin/mender-artifact /binary" && \
-	docker image rm $$image_id
-
 build-natives-contained:
 	rm -f mender-artifact && \
 	image_id=$$(docker build -f Dockerfile.binaries . | awk '/Successfully built/{print $$NF;}') && \


### PR DESCRIPTION
this is mostly in preparation for changes in `create-artifact-worker`...
also I'm not sure if the "docker image only" build is used anywhere else, but in this repo it only seems to be the `.binaries` one...