### PR TITLE
chore: Switch mender-artifact to ubuntu:22 based builder.

### DIFF
--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -1,8 +1,10 @@
-FROM golang:1.18 as builder
+# This should be switched back to golang-x.xx at some point, but make sure it
+# has libssl.so.3 before doing so.
+FROM ubuntu:22.04 as builder
 RUN apt-get update && \
     apt-get install -y \
     gcc gcc-mingw-w64 gcc-multilib \
-    git make \
+    git make golang-1.18 golang \
     musl-dev liblzma-dev libssl-dev
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact


### PR DESCRIPTION
This is done in order to link to libssl.so.3 instead of libssl.so.1.1.
Unfortunately ubuntu < 22 and ubuntu >= 22 are completely incompatible
in this regard, so we can't build one single binary which will work on
both of them.

We will solve this with a more generic distro package approach later.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>