### PR TITLE
chore: Explicitly build binaries with OpenSSL 1.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,8 @@ test:smoketests:linux:
     - ./mender-artifact-linux write rootfs-image -t test -o test-rfs.mender -n test -f test.txt
     - ./mender-artifact-linux read test-rfs.mender
     - ./mender-artifact-linux validate test-rfs.mender
+    # QA-507: lock mender-artifact to OpenSSL 1.1
+    - ldd ./mender-artifact-linux | grep libssl.so.1.1
     - make build
 
 test:coverage:linux:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.19.3-bullseye as builder
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.19.3-bullseye as builder
 RUN apt-get update && \
     apt-get install -y \
     gcc gcc-mingw-w64 gcc-multilib \


### PR DESCRIPTION
Explicitly use Docker base images with `-bullseye` and add a line in the smoke tests to check for the shared symbol.