### PR TITLE
fix(crypto): Support signing with keys in the PKCS8 format

### DIFF
--- a/artifact/signer.go
+++ b/artifact/signer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -291,6 +291,18 @@ func GetKeyAndSignMethod(keyPEM []byte) (*SigningMethod, error) {
 			return nil, errors.Wrap(err, "signer: can not extract public RSA key")
 		}
 		return &SigningMethod{Key: rsaKey, Public: pub, Method: new(RSA)}, nil
+	}
+	anyKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err == nil {
+		// Verify that it's an RSA key
+		rsaKey, ok := anyKey.(*rsa.PrivateKey)
+		if ok {
+			pub, keyErr := x509.MarshalPKIXPublicKey(rsaKey.Public())
+			if keyErr != nil {
+				return nil, errors.Wrap(err, "signer: can not extract public RSA key")
+			}
+			return &SigningMethod{Key: rsaKey, Public: pub, Method: new(RSA)}, nil
+		}
 	}
 	ecdsaKey, err := x509.ParseECPrivateKey(block.Bytes)
 	if err == nil {


### PR DESCRIPTION
Ticket: None
Changelog: Support extracting RSA keys for signing artifacts from the PKCSv8 format.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>