### PR TITLE
ci: Explicitly set golang version to 1.17

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,8 @@ include:
   - project: "Northern.tech/Mender/mendertesting"
     file: ".gitlab-ci-check-license.yml"
 
-image: golang:1.18-alpine3.16
+# Keep golang version aligned with latest yocto release
+image: golang:1.17-alpine3.16
 
 cache:
   paths:
@@ -193,7 +194,6 @@ test:unit:mac:
 
 publish:tests:
   stage: publish
-  image: golang:1.14-alpine3.11
   needs:
     - job: test:unit:linux
       artifacts: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.19.5-bullseye as builder
+# Keep golang version aligned with latest yocto release
+FROM golang:1.17.13-bullseye as builder
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -1,4 +1,5 @@
-FROM golang:1.19.5-bullseye as builder
+# Keep golang version aligned with latest yocto release
+FROM golang:1.17.13-bullseye as builder
 RUN apt-get update && \
     apt-get install -y \
     gcc gcc-mingw-w64 gcc-multilib \


### PR DESCRIPTION
As agreed in the client team, we shall stick to the golang version present in the latest release of yocto LTS.