### PR TITLE
ci: Finalize coverage report from individual pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,6 +204,7 @@ publish:tests:
       artifacts: true
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
+    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
   before_script:
     - go install github.com/mattn/goveralls@v0.0.12
     # Coveralls env variables:
@@ -228,6 +229,9 @@ publish:tests:
       -flagname unittests:$PLATFORM
       -coverprofile coverage-$PLATFORM.txt
     - done
+    # Finalize the report
+    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
+    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'
 
 publish:s3:
   stage: publish


### PR DESCRIPTION
Previously the pipeline relied on the mender-qa pipeline to finalize the
report after submitting coverage from acceptance tests. However the
coverage from client acceptance tests will be removed soon so we
can already disregard it and make sure we have enough coverage with unit
tests.
    
See:
* https://github.com/mendersoftware/mender-qa/pull/709