### PR TITLE
Add build constraint to allow compiling without `cgo`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep golang version aligned with latest yocto release
-FROM golang:1.17.13-bullseye as builder
+FROM golang:1.22.2-bullseye as builder
 RUN mkdir -p /go/src/github.com/mendersoftware/mender-artifact
 WORKDIR /go/src/github.com/mendersoftware/mender-artifact
 ADD ./ .

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -1,5 +1,5 @@
 # Keep golang version aligned with latest yocto release
-FROM golang:1.17.13-bullseye as builder
+FROM golang:1.22.2-bullseye as builder
 RUN apt-get update && \
     apt-get install -y \
     gcc gcc-mingw-w64 gcc-multilib \

--- a/artifact/signer_linux.go
+++ b/artifact/signer_linux.go
@@ -12,8 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-//go:build linux
-// +build linux
+//go:build linux && cgo
+// +build linux,cgo
 
 package artifact
 

--- a/artifact/signer_unsupported.go
+++ b/artifact/signer_unsupported.go
@@ -12,8 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-//go:build !linux
-// +build !linux
+//go:build !linux || !cgo
+// +build !linux !cgo
 
 package artifact
 


### PR DESCRIPTION
The PKCS11 feature (not used by the backend) prevents compiling mender-artifact without enabling `cgo`.