### PR TITLE
MEN-7876: Restore tty echo also when cancelling the context

### DIFF
--- a/cli/util/tty.go
+++ b/cli/util/tty.go
@@ -58,6 +58,7 @@ func EchoSigHandler(
 		select {
 		case <-ctx.Done():
 			errChan <- nil
+			_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), ioctlSetTermios, term)
 			return
 		case sig, sigRecved = <-sigChan:
 		}


### PR DESCRIPTION
Changelog: Fix an issue with writing Artifact from a remote ssh connection where the user terminal was left with no echo if the `ssh` subprocess exited prematurely.