### PR TITLE
fix: Improve the error message when verifying ECDSA keys supplied via…

### DIFF
--- a/artifact/signer.go
+++ b/artifact/signer.go
@@ -180,7 +180,8 @@ func UnmarshalECDSASignature(sig []byte) (r, s *big.Int, e error) {
 		return UnmarshalECDSASignatureASN1(sig)
 	}
 
-	return nil, nil, errors.Errorf("signer: invalid ecdsa key size: %d", len(sig))
+	return nil, nil, errors.Errorf("signer: invalid signature length: %d. "+
+		"For ECDSA only P-256 is supported.", len(sig))
 }
 
 func UnmarshalECDSASignatureASN1(sig []byte) (r *big.Int, s *big.Int, err error) {

--- a/artifact/signer_test.go
+++ b/artifact/signer_test.go
@@ -259,10 +259,10 @@ func TestECDSARaw(t *testing.T) {
 	// use wrong size key for verification
 	err = r.Verify([]byte("my message"), []byte("signature"), crypt.Key)
 	assert.Error(t, err)
-	assert.Contains(t, errors.Cause(err).Error(), "signer: invalid ecdsa key size:")
+	assert.Contains(t, errors.Cause(err).Error(), "signer: invalid signature length:")
 
 	// use wrong size key for verification
 	err = r.Verify([]byte("my message"), []byte("signature longer than the 72 bytes for 256 means that we definitely are having something we do not recognize in any way, which should happen here, ever since MEN-7523."), crypt.Key)
 	assert.Error(t, err)
-	assert.Contains(t, errors.Cause(err).Error(), "invalid ecdsa key size")
+	assert.Contains(t, errors.Cause(err).Error(), "invalid signature length")
 }


### PR DESCRIPTION
… PKCS#11

When validating signatures with ECDSA keys exported from HSMs where the key is not P-256, i.e. the signature field length is not the correct length for P-256, inform that only ECDSA P-256 is supported.

Ticket: MEN-7941
Changelog: Title