### PR TITLE
MEN-8269: Publish Mac OS (and Windows) binaries on Git tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,12 +256,11 @@ publish:s3:
   needs:
     - job: build:make
       artifacts: true
-    - job: test:smoketests:linux
     - job: test:smoketests:mac
   before_script:
     - apt update && apt install -yyq awscli
   script:
-    - for bin in mender-artifact-darwin mender-artifact-linux mender-artifact-windows.exe; do
+    - for bin in mender-artifact-darwin mender-artifact-windows.exe; do
       platform=${bin#mender-artifact-};
       platform=${platform%.*};
       echo "Publishing ${CI_COMMIT_REF_NAME} version for ${platform} to S3";

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ cache:
     - /go/src/gopkg.in
 
 variables:
+  DEFAULT_BRANCH: "master"
   DOCKER_HOST: tcp://docker:2375/
   DOCKER_REPOSITORY: mendersoftware/mender-artifact
   S3_BUCKET_NAME: "mender"
@@ -253,6 +254,12 @@ publish:tests:
 publish:s3:
   stage: publish
   image: debian:bookworm-slim
+  rules:
+    # Publish for build and final tags + default and maintenance branches
+    - if: '$CI_COMMIT_TAG =~ /^\d+\.\d+\.\d+$/'
+    - if: '$CI_COMMIT_TAG =~ /^\d+\.\d+\.\d+-build\d+$/'
+    - if: '$CI_COMMIT_BRANCH =~ /^\d+\.\d+\.x$/'
+    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
   needs:
     - job: build:make
       artifacts: true
@@ -269,5 +276,3 @@ publish:s3:
       aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
       --key $S3_BUCKET_PATH/${CI_COMMIT_REF_NAME}/${platform}/mender-artifact;
       done
-  only:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/


### PR DESCRIPTION
    Historically the publishing of binaries from tags was delegated to
    `mender-qa` repository. This was removed some time ago in the context of
    switching from binaries to packages but the Mac OS (and Windows)
    binaries got lost in the process.
    
    See:
    * https://github.com/mendersoftware/mender-qa/commit/67b1b6bcd66af18b5b52814fde30ac3656473f5b
    
    Repurpose the existing CI job here that was publishing the binaries for
    branches to take care of the tags too, modernizing a bit the CI spec
    along the way.