### PR TITLE
chore: Look for binaries in brew specific path

### DIFF
--- a/cli/debugfs_test.go
+++ b/cli/debugfs_test.go
@@ -45,10 +45,14 @@ func TestExternalBinaryDependency(t *testing.T) {
 	origPATH := os.Getenv("PATH")
 	// "/usr/sbin", "/sbin", "/usr/local/sbin" also needs to be unset
 	origExternalBinaryPaths := utils.ExternalBinaryPaths
+	// also make sure that Mac Brew specific paths are not set
+	origBrewSpecificPaths := utils.BrewSpecificPaths
 	utils.ExternalBinaryPaths = []string{}
+	utils.BrewSpecificPaths = []string{}
 	defer func() {
 		os.Setenv("PATH", origPATH)
 		utils.ExternalBinaryPaths = origExternalBinaryPaths
+		utils.BrewSpecificPaths = origBrewSpecificPaths
 	}()
 	os.Setenv("PATH", "")
 	tmpdir, err := debugfsCopyFile("foo", "bar")


### PR DESCRIPTION
When brew installs binary it will create symlink directory in location like `/usr/local/opt/<binary>/bin`. This location is not part of the system PATH by default.

When mender-artifact evaluates commands location it need to check this brew specific directories apart of default ones.

ticket: MEN-8471
changelog: Extend tools search locations with brew specific ones