### PR TITLE
chore: Add help info when no make target specified

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,7 +237,10 @@ test:unit:mac:
     - mac-runner
   before_script:
     # fsck.ext4 is required for the tests
-    - brew install e2fsprogs
+    # From some reason brew does not installed e2fsprogs
+    # correct and has not created valid links. This is the reason
+    # why we are forcing to reinstall it
+    - brew reinstall e2fsprogs
   after_script:
     # we want a clean environment on the runner for testing `brew install
     # mender-artifact` (which pulls `e2fsprogs`, among others, as a dependency)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,26 @@ ifneq ($(GOOS),linux)
 	TAGS += nopkcs11
 endif
 
+default: help
+
+help:
+	@echo "make [TARGETS...]"
+	@echo
+	@echo "The following targets are available:"
+	@echo
+	@echo "    help:               Print this usage information."
+	@echo
+	@echo "    build:              Build the code on the localhost"
+	@echo "    build-contained:    Build the code in the container"
+	@echo "    clean:              Remove build artifacts"
+	@echo
+	@echo "    install:            Install build artifacts on the locally"
+	@echo "    uninstall:          Uninstall build artifacts from the localhost"
+	@echo
+	@echo "    test:               Run tests"
+	@echo "    check:              Run various code checking tools"
+	@echo "    coverage:           Run code coverage checks"
+
 build:
 	$(GO) build $(GO_LDFLAGS) $(BUILDV) -tags '$(TAGS)'
 
@@ -147,6 +167,6 @@ coverage:
 	rm -f coverage.txt
 	go test -tags '$(TAGS)' -covermode=atomic -coverpkg=$(PKGS) -coverprofile=coverage.txt ./...
 
-.PHONY: build clean get-tools test check \
+.PHONY: help build clean get-tools test check \
 	cover htmlcover coverage tooldep install-autocomplete-scripts \
 	instrument-binary

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To build `mender-artifact` from source you need the following prerequisites:
 
 In the source directory, `mender-artifact` is built by simply issueing
 ```
-make
+make build
 ```
 
 This results in the self-contained binary `mender-artifact`. You can leave it in place,


### PR DESCRIPTION
In the documentation addressing `build from source` we suggest users to follow
repository instructions for each repo. `mender-artifact` is based on plain Makefile
and when `make` is called without extra parameters build on host will be performed.

In README we suggest to use `make build-natives-contained` as a main build command.
This is not what Makefile is doing by default.

My proposition is to introduce `help` target with displaying some most popular targets,
but not performing any (potential harmful) action by default.

This way user will need to explicite tell `make` what action needs to be performed. 

Ticket: None
Changelog: Add help info to Makefile targets