### PR TITLE
fix: mender-artifact hangs when ssh connection fails silently

### DIFF
--- a/cli/util/ssh.go
+++ b/cli/util/ssh.go
@@ -73,6 +73,8 @@ func StartSSHCommand(c *cli.Context,
 	args = append(args, userAtHost)
 	args = append(
 		args,
+		"-o ServerAliveInterval=30",
+		"-o ServerAliveCountMax=1",
 		"/bin/sh",
 		"-c",
 		command)


### PR DESCRIPTION
Ticket: MEN-8429
Changelog: Fix for mender-artifact waiting indefinitely if ssh connection fails silently. Now it drops after 30 seconds.