### PR TITLE
QA-1166: Move (restore) `brew-build` out of the release comopnents

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,9 @@ include:
       - '.gitlab-ci-check-commits-signoffs.yml'
   - project: "Northern.tech/Mender/mendertesting"
     file: ".gitlab-ci-check-license.yml"
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/brew-build@master
+    inputs:
+      formula: "m/mender-artifact.rb"
 
   # Release CI/CD components
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-candidate@master
@@ -28,9 +31,6 @@ include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-dist-packages@master
     inputs:
       package: MENDER_ARTIFACT
-  - component: gitlab.com/Northern.tech/Mender/mendertesting/brew-build@master
-    inputs:
-      formula: "m/mender-artifact.rb"
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-compass@master
     inputs:
       compass_component_id: "3a6f19a5-306f-4900-93f6-c2e953eac6e8"


### PR DESCRIPTION
This was my bad understanding of what the CI/CD template does: build and test. The "release" part happens separately and will be a manual step.