### PR TITLE
Remove mendersoftware/deadcode tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ export CGO_ENABLED
 
 TOOLS = \
 	github.com/fzipp/gocyclo/... \
-	github.com/opennota/check/cmd/varcheck \
-	github.com/mendersoftware/deadcode
+	github.com/opennota/check/cmd/varcheck
 
 VERSION = $(shell git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
 
@@ -134,8 +133,6 @@ extracheck:
 	fi
 	echo "-- checking with govet"
 	$(GO) vet -unsafeptr=false
-	echo "-- checking for dead code"
-	deadcode
 	echo "-- checking with varcheck"
 	varcheck .
 	echo "-- checking cyclometric complexity > $(GOCYCLO)"


### PR DESCRIPTION
Jira ticket - https://northerntech.atlassian.net/browse/QA-923

The mendersoftware/deadcode repo is being archived (9 years unmaintained). Remove it from TOOLS and the extracheck target.


Ticket: QA-923