### PR TITLE
fix(cli): Exit with non-zero code on invalid arguments

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	errArtifactInvalidParameters = iota
+	errArtifactInvalidParameters = iota + 1
 	errArtifactUnsupportedVersion
 	errArtifactCreate
 	errArtifactOpen


### PR DESCRIPTION
The error code constants were defined with a bare iota, making `errArtifactInvalidParameters` equal to 0. Any call to `cli.NewExitError(..., errArtifactInvalidParameters)` would therefore exit successfully, turning hard errors into silent warnings.