### PR TITLE
fix: Replace --device-type with --compatible-types when dumping cmdline

### DIFF
--- a/cli/dump.go
+++ b/cli/dump.go
@@ -204,8 +204,9 @@ func printCmdline(ar *areader.Reader, args []string, sep, endChar rune) {
 				strings.Join(artDeps.ArtifactName,
 					fmt.Sprintf("%c--artifact-name-depends%c", sep, sep)))
 		}
-		fmt.Printf("%c--device-type%c%s", sep, sep,
-			strings.Join(artDeps.CompatibleDevices, fmt.Sprintf("%c--device-type%c", sep, sep)))
+		fmt.Printf("%c--compatible-types%c%s", sep, sep,
+			strings.Join(artDeps.CompatibleDevices,
+				fmt.Sprintf("%c--compatible-types%c", sep, sep)))
 		if len(artDeps.ArtifactGroup) > 0 {
 			fmt.Printf("%c--depends-groups%c%s", sep, sep,
 				strings.Join(artDeps.ArtifactGroup, fmt.Sprintf("%c--depends-groups%c", sep, sep)))
@@ -213,8 +214,8 @@ func printCmdline(ar *areader.Reader, args []string, sep, endChar rune) {
 
 	} else if ar.GetInfo().Version == 2 {
 		fmt.Printf("%c--artifact-name%c%s", sep, sep, ar.GetArtifactName())
-		fmt.Printf("%c--device-type%c%s", sep, sep,
-			strings.Join(ar.GetCompatibleDevices(), " --device-type "))
+		fmt.Printf("%c--compatible-types%c%s", sep, sep,
+			strings.Join(ar.GetCompatibleDevices(), " --compatible-types "))
 	}
 
 	handlers := ar.GetHandlers()

--- a/cli/dump_test.go
+++ b/cli/dump_test.go
@@ -143,7 +143,7 @@ func testDumpContent(t *testing.T, imageType, printCmdline string) {
 			" --artifact-name Name"+
 			" --provides-group providesGroup"+
 			" --artifact-name-depends dependsOnArtifact"+
-			" --device-type TestDevice"+
+			" --compatible-types TestDevice"+
 			" --depends-groups dependsGroup"+
 			" --type %s"+
 			" --no-default-software-version"+
@@ -216,8 +216,8 @@ func testDumpContent(t *testing.T, imageType, printCmdline string) {
 			" --provides-group providesGroup"+
 			" --artifact-name-depends dependsOnArtifact"+
 			" --artifact-name-depends dependsOnArtifact2"+
-			" --device-type TestDevice"+
-			" --device-type TestDevice2"+
+			" --compatible-types TestDevice"+
+			" --compatible-types TestDevice2"+
 			" --depends-groups dependsGroup"+
 			" --depends-groups dependsGroup2"+
 			fmt.Sprintf(" --type %s", imageType)+


### PR DESCRIPTION
`--device-type` is deprecated since 0eb186e0baf2381658160d289462.

Ticket: MEN-9010
Changelog: none