### PR TITLE
feat(cli): add server integration for artifact interactions

### DIFF
--- a/cli/server/auth.go
+++ b/cli/server/auth.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	DefaultServer = "https://hosted.mender.io"
+	tokenFileName = "authtoken"
+	tokenDirName  = "mender"
+)
+
+func tokenPath() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		u, err := user.Current()
+		if err != nil {
+			return "", errors.New("cannot determine home directory")
+		}
+		home = u.HomeDir
+	}
+
+	cacheDir := os.Getenv("XDG_CACHE_HOME")
+	if cacheDir == "" {
+		cacheDir = filepath.Join(home, ".cache")
+	}
+
+	newPath := filepath.Join(cacheDir, tokenDirName, tokenFileName)
+
+	oldPath := filepath.Join(home, ".mender", tokenFileName)
+	if _, err := os.Stat(oldPath); err == nil {
+		if _, err := os.Stat(newPath); os.IsNotExist(err) {
+			if err := os.MkdirAll(filepath.Dir(newPath), 0700); err == nil {
+				_ = os.Rename(oldPath, newPath)
+			}
+		}
+	}
+
+	return newPath, nil
+}
+
+func SaveToken(token string) error {
+	path, err := tokenPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return errors.Wrap(err, "failed to create token directory")
+	}
+
+	return os.WriteFile(path, []byte(token), 0600)
+}
+
+func LoadToken() (string, error) {
+	path, err := tokenPath()
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"no authentication token found; run 'mender-artifact login' first or use --token",
+			)
+		}
+		return "", errors.Wrap(err, "failed to read auth token")
+	}
+
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("auth token is empty; run 'mender-artifact login' to re-authenticate")
+	}
+
+	return token, nil
+}
+
+func ResolveToken(tokenFlag string) (string, error) {
+	if tokenFlag != "" {
+		return tokenFlag, nil
+	}
+	return LoadToken()
+}

--- a/cli/server/auth_test.go
+++ b/cli/server/auth_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadToken(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	err := SaveToken("test-jwt-token")
+	if err != nil {
+		t.Fatalf("SaveToken failed: %s", err)
+	}
+
+	token, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken failed: %s", err)
+	}
+	if token != "test-jwt-token" {
+		t.Errorf("got %q, want test-jwt-token", token)
+	}
+}
+
+func TestLoadTokenNotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, ".cache"))
+
+	_, err := LoadToken()
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+}
+
+func TestLoadTokenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	tokenDir := filepath.Join(cacheDir, "mender")
+	os.MkdirAll(tokenDir, 0700)
+	os.WriteFile(filepath.Join(tokenDir, "authtoken"), []byte("  \n"), 0600)
+
+	_, err := LoadToken()
+	if err == nil {
+		t.Fatal("expected error for empty token, got nil")
+	}
+}
+
+func TestResolveTokenWithFlag(t *testing.T) {
+	token, err := ResolveToken("explicit-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if token != "explicit-token" {
+		t.Errorf("got %q, want explicit-token", token)
+	}
+}
+
+func TestResolveTokenFallsBackToStored(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	SaveToken("stored-token")
+
+	token, err := ResolveToken("")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if token != "stored-token" {
+		t.Errorf("got %q, want stored-token", token)
+	}
+}
+
+func TestSaveTokenCreatesDir(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "deep", "nested", ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	err := SaveToken("deep-token")
+	if err != nil {
+		t.Fatalf("SaveToken failed: %s", err)
+	}
+
+	token, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken failed: %s", err)
+	}
+	if token != "deep-token" {
+		t.Errorf("got %q, want deep-token", token)
+	}
+}
+
+func TestTokenPathXDGDefault(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	err := SaveToken("xdg-test")
+	if err != nil {
+		t.Fatalf("SaveToken failed: %s", err)
+	}
+
+	expected := filepath.Join(dir, ".cache", "mender", "authtoken")
+	data, err := os.ReadFile(expected)
+	if err != nil {
+		t.Fatalf("token not at expected default path: %s", err)
+	}
+	if string(data) != "xdg-test" {
+		t.Errorf("got %q, want xdg-test", string(data))
+	}
+}
+
+func TestTokenMigrationSkippedWhenNewExists(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	oldDir := filepath.Join(dir, ".mender")
+	os.MkdirAll(oldDir, 0700)
+	os.WriteFile(
+		filepath.Join(oldDir, "authtoken"),
+		[]byte("old-token"), 0600,
+	)
+
+	newDir := filepath.Join(cacheDir, "mender")
+	os.MkdirAll(newDir, 0700)
+	os.WriteFile(
+		filepath.Join(newDir, "authtoken"),
+		[]byte("new-token"), 0600,
+	)
+
+	token, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken failed: %s", err)
+	}
+	if token != "new-token" {
+		t.Errorf("got %q, want new-token (migration should be skipped)", token)
+	}
+}
+
+func TestResolveTokenNoStoredToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, ".cache"))
+
+	_, err := ResolveToken("")
+	if err == nil {
+		t.Fatal("expected error when no token stored and no flag")
+	}
+}
+
+func TestLoadTokenReadError(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	tokenDir := filepath.Join(cacheDir, "mender")
+	os.MkdirAll(tokenDir, 0700)
+	tokenFile := filepath.Join(tokenDir, "authtoken")
+	os.Mkdir(tokenFile, 0700)
+
+	_, err := LoadToken()
+	if err == nil {
+		t.Fatal("expected error when token path is a directory")
+	}
+}
+
+func TestTokenMigration(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".cache")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	oldDir := filepath.Join(dir, ".mender")
+	os.MkdirAll(oldDir, 0700)
+	os.WriteFile(
+		filepath.Join(oldDir, "authtoken"),
+		[]byte("migrated-token"), 0600,
+	)
+
+	token, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken failed: %s", err)
+	}
+	if token != "migrated-token" {
+		t.Errorf("got %q, want migrated-token", token)
+	}
+
+	newPath := filepath.Join(cacheDir, "mender", "authtoken")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("token not migrated to new path: %s", err)
+	}
+}

--- a/cli/server/client.go
+++ b/cli/server/client.go
@@ -1,0 +1,528 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	loginURL            = "/api/management/v1/useradm/auth/login"
+	artifactUploadURL   = "/api/management/v1/deployments/artifacts"
+	artifactsListURL    = "/api/management/v1/deployments/artifacts/list"
+	artifactURL         = "/api/management/v1/deployments/artifacts/:id"
+	artifactDownloadURL = "/api/management/v1/deployments/artifacts/:id/download"
+)
+
+type ArtifactInfo struct {
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	Description           string   `json:"description"`
+	DeviceTypesCompatible []string `json:"device_types_compatible"`
+	Size                  int64    `json:"size"`
+	Modified              string   `json:"modified"`
+	Info                  struct {
+		Format  string `json:"format"`
+		Version int    `json:"version"`
+	} `json:"info"`
+	Signed  bool `json:"signed"`
+	Updates []struct {
+		TypeInfo struct {
+			Type string `json:"type"`
+		} `json:"type_info"`
+	} `json:"updates"`
+}
+
+type DownloadLink struct {
+	URI    string    `json:"uri"`
+	Expire time.Time `json:"expire"`
+}
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string, skipVerify bool) *Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify}, //nolint:gosec
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Transport: tr,
+		},
+	}
+}
+
+func (c *Client) Login(user, pass, tfaToken string) (string, error) {
+	url := c.baseURL + loginURL
+
+	var reqBody io.Reader
+	if tfaToken != "" {
+		reqBody = strings.NewReader(`{"token2fa":"` + tfaToken + `"}`)
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, url, reqBody,
+	)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create login request")
+	}
+	req.SetBasicAuth(user, pass)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "login request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read login response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("login failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return strings.TrimSpace(string(body)), nil
+}
+
+func (c *Client) UploadArtifact(artifactPath, token, description string) error {
+	fi, err := os.Stat(artifactPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to stat artifact file")
+	}
+
+	artifactFile, err := os.Open(artifactPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to open artifact file")
+	}
+	defer artifactFile.Close()
+
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+
+	go func() {
+		defer pw.Close()
+
+		_ = writer.WriteField("size", strconv.FormatInt(fi.Size(), 10))
+		if description != "" {
+			_ = writer.WriteField("description", description)
+		}
+
+		part, err := writer.CreateFormFile("artifact", filepath.Base(artifactPath))
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err = io.Copy(part, artifactFile); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		writer.Close()
+	}()
+
+	url := c.baseURL + artifactUploadURL
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, url, pr,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create upload request")
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "upload request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read upload response")
+	}
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return nil
+	case http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized: please run 'mender-artifact login' first")
+	case http.StatusConflict:
+		return fmt.Errorf("artifact already exists with same name/depends: %s", string(body))
+	default:
+		return fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func (c *Client) ListArtifacts(token string, page, perPage int) ([]ArtifactInfo, error) {
+	url := fmt.Sprintf("%s%s?page=%d&per_page=%d", c.baseURL, artifactsListURL, page, perPage)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, url, nil,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create list request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "list request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read list response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var artifacts []ArtifactInfo
+	if err := json.Unmarshal(body, &artifacts); err != nil {
+		return nil, errors.Wrap(err, "failed to parse artifact list")
+	}
+
+	return artifacts, nil
+}
+
+func (c *Client) GetArtifact(artifactID, token string) (*ArtifactInfo, error) {
+	url := strings.Replace(c.baseURL+artifactURL, ":id", artifactID, 1)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, url, nil,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create get request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "get artifact request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read artifact response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get artifact failed with status %d: %s",
+			resp.StatusCode, string(body))
+	}
+
+	var artifact ArtifactInfo
+	if err := json.Unmarshal(body, &artifact); err != nil {
+		return nil, errors.Wrap(err, "failed to parse artifact info")
+	}
+
+	return &artifact, nil
+}
+
+func (c *Client) DeleteArtifact(artifactID, token string) error {
+	url := strings.Replace(c.baseURL+artifactURL, ":id", artifactID, 1)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodDelete, url, nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create delete request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "delete artifact request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read delete response")
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized: please run 'login' first")
+	default:
+		return fmt.Errorf("delete failed with status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func (c *Client) getDownloadLink(artifactID, token string) (*DownloadLink, error) {
+	url := strings.Replace(c.baseURL+artifactDownloadURL, ":id", artifactID, 1)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, url, nil,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create download link request")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "download link request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read download link response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download link failed with status %d: %s",
+			resp.StatusCode, string(body))
+	}
+
+	var link DownloadLink
+	if err := json.Unmarshal(body, &link); err != nil {
+		return nil, errors.Wrap(err, "failed to parse download link")
+	}
+
+	return &link, nil
+}
+
+func (c *Client) DownloadArtifact(artifactID, token, outputPath string) error {
+	artifact, err := c.GetArtifact(artifactID, token)
+	if err != nil {
+		return err
+	}
+
+	link, err := c.getDownloadLink(artifactID, token)
+	if err != nil {
+		return err
+	}
+
+	if outputPath == "" {
+		outputPath = artifact.Name + ".mender"
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, link.URI, nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create download request")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "download request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create output file")
+	}
+	defer f.Close()
+
+	written, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to write artifact file")
+	}
+
+	fmt.Fprintf(os.Stderr, "Downloaded %s (%d bytes) to %s\n", artifact.Name, written, outputPath)
+	return nil
+}
+
+func (c *Client) FindArtifactsByName(name, token string) ([]ArtifactInfo, error) {
+	var matches []ArtifactInfo
+	page := 1
+	for {
+		artifacts, err := c.ListArtifacts(token, page, 100)
+		if err != nil {
+			return nil, err
+		}
+		if len(artifacts) == 0 {
+			break
+		}
+		for i := range artifacts {
+			if artifacts[i].Name == name {
+				matches = append(matches, artifacts[i])
+			}
+		}
+		page++
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("artifact %q not found", name)
+	}
+	return matches, nil
+}
+
+func (c *Client) FindArtifactByName(name, deviceType, token string) (*ArtifactInfo, error) {
+	matches, err := c.FindArtifactsByName(name, token)
+	if err != nil {
+		return nil, err
+	}
+
+	if deviceType != "" {
+		var filtered []ArtifactInfo
+		for _, a := range matches {
+			for _, dt := range a.DeviceTypesCompatible {
+				if dt == deviceType {
+					filtered = append(filtered, a)
+					break
+				}
+			}
+		}
+		if len(filtered) == 0 {
+			return nil, fmt.Errorf(
+				"artifact %q found but none compatible with device type %q", name, deviceType)
+		}
+		matches = filtered
+	}
+
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "artifact name %q matches %d artifacts (a release). ", name, len(matches))
+	fmt.Fprintf(&buf, "Use --device-type to filter or specify the artifact ID directly:\n")
+	for _, a := range matches {
+		fmt.Fprintf(&buf, "  %s  device types: %s\n",
+			a.ID, strings.Join(a.DeviceTypesCompatible, ", "))
+	}
+	return nil, fmt.Errorf("%s", buf.String())
+}
+
+func (c *Client) DownloadArtifactByName(name, deviceType, token, outputPath string) error {
+	artifact, err := c.FindArtifactByName(name, deviceType, token)
+	if err != nil {
+		return err
+	}
+	return c.DownloadArtifact(artifact.ID, token, outputPath)
+}
+
+func (c *Client) DownloadArtifactToTempDir(artifactID, token, tmpDir string) (string, error) {
+	artifact, err := c.GetArtifact(artifactID, token)
+	if err != nil {
+		return "", err
+	}
+
+	link, err := c.getDownloadLink(artifactID, token)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, link.URI, nil,
+	)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create download request")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "download request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	outputPath := filepath.Join(tmpDir, artifact.Name+".mender")
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temp file")
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return "", errors.Wrap(err, "failed to write artifact")
+	}
+
+	return outputPath, nil
+}
+
+func FormatArtifactList(artifacts []ArtifactInfo) string {
+	if len(artifacts) == 0 {
+		return "No artifacts found."
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%-36s  %-30s  %-20s  %-10s  %s\n",
+		"ID", "NAME", "TYPE", "SIZE", "MODIFIED")
+	fmt.Fprintf(&buf, "%-36s  %-30s  %-20s  %-10s  %s\n",
+		strings.Repeat("-", 36),
+		strings.Repeat("-", 30),
+		strings.Repeat("-", 20),
+		strings.Repeat("-", 10),
+		strings.Repeat("-", 20))
+
+	for _, a := range artifacts {
+		artType := ""
+		if len(a.Updates) > 0 {
+			artType = a.Updates[0].TypeInfo.Type
+		}
+		sizeStr := formatBytes(a.Size)
+		modified := a.Modified
+		if len(modified) > 19 {
+			modified = modified[:19]
+		}
+		name := a.Name
+		if len(name) > 30 {
+			name = name[:27] + "..."
+		}
+		fmt.Fprintf(&buf, "%-36s  %-30s  %-20s  %-10s  %s\n",
+			a.ID, name, artType, sizeStr, modified)
+	}
+
+	return buf.String()
+}
+
+func formatBytes(b int64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+}

--- a/cli/server/client_test.go
+++ b/cli/server/client_test.go
@@ -1,0 +1,863 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testServer(handler http.HandlerFunc) (*httptest.Server, *Client) {
+	ts := httptest.NewServer(handler)
+	client := NewClient(ts.URL, false)
+	return ts, client
+}
+
+func TestLogin(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != loginURL {
+			http.NotFound(w, r)
+			return
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "admin" || pass != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprint(w, "jwt-token-value")
+	})
+	defer ts.Close()
+
+	token, err := client.Login("admin", "secret", "")
+	if err != nil {
+		t.Fatalf("Login failed: %s", err)
+	}
+	if token != "jwt-token-value" {
+		t.Errorf("got %q, want jwt-token-value", token)
+	}
+}
+
+func TestLoginWith2FA(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"token2fa":"123456"`) {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, "2fa required")
+			return
+		}
+		fmt.Fprint(w, "jwt-2fa-token")
+	})
+	defer ts.Close()
+
+	token, err := client.Login("admin", "secret", "123456")
+	if err != nil {
+		t.Fatalf("Login failed: %s", err)
+	}
+	if token != "jwt-2fa-token" {
+		t.Errorf("got %q, want jwt-2fa-token", token)
+	}
+}
+
+func TestLoginFailure(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, "bad credentials")
+	})
+	defer ts.Close()
+
+	_, err := client.Login("wrong", "creds", "")
+	if err == nil {
+		t.Fatal("expected error for failed login")
+	}
+}
+
+func TestUploadArtifact(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if !strings.HasPrefix(
+			r.Header.Get("Content-Type"), "multipart/form-data",
+		) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+	defer ts.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "test.mender")
+	os.WriteFile(tmpFile, []byte("artifact-data"), 0600)
+
+	err := client.UploadArtifact(tmpFile, "token", "test upload")
+	if err != nil {
+		t.Fatalf("UploadArtifact failed: %s", err)
+	}
+}
+
+func TestUploadArtifactConflict(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, "duplicate")
+	})
+	defer ts.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "test.mender")
+	os.WriteFile(tmpFile, []byte("data"), 0600)
+
+	err := client.UploadArtifact(tmpFile, "token", "")
+	if err == nil {
+		t.Fatal("expected error for conflict")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestUploadArtifactUnauthorized(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	defer ts.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "test.mender")
+	os.WriteFile(tmpFile, []byte("data"), 0600)
+
+	err := client.UploadArtifact(tmpFile, "bad-token", "")
+	if err == nil {
+		t.Fatal("expected error for unauthorized")
+	}
+	if !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestListArtifacts(t *testing.T) {
+	artifacts := []ArtifactInfo{
+		{ID: "id-1", Name: "art-1", Size: 1024},
+		{ID: "id-2", Name: "art-2", Size: 2048},
+	}
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(artifacts)
+	})
+	defer ts.Close()
+
+	result, err := client.ListArtifacts("token", 1, 20)
+	if err != nil {
+		t.Fatalf("ListArtifacts failed: %s", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 artifacts, got %d", len(result))
+	}
+	if result[0].Name != "art-1" {
+		t.Errorf("got %q, want art-1", result[0].Name)
+	}
+}
+
+func TestListArtifactsError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "internal error")
+	})
+	defer ts.Close()
+
+	_, err := client.ListArtifacts("token", 1, 20)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetArtifact(t *testing.T) {
+	artifact := ArtifactInfo{
+		ID: "abc-123", Name: "my-artifact", Size: 4096,
+	}
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "abc-123") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(artifact)
+	})
+	defer ts.Close()
+
+	result, err := client.GetArtifact("abc-123", "token")
+	if err != nil {
+		t.Fatalf("GetArtifact failed: %s", err)
+	}
+	if result.Name != "my-artifact" {
+		t.Errorf("got %q, want my-artifact", result.Name)
+	}
+}
+
+func TestGetArtifactNotFound(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "not found")
+	})
+	defer ts.Close()
+
+	_, err := client.GetArtifact("missing-id", "token")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
+func TestDeleteArtifact(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer ts.Close()
+
+	err := client.DeleteArtifact("abc-123", "token")
+	if err != nil {
+		t.Fatalf("DeleteArtifact failed: %s", err)
+	}
+}
+
+func TestDeleteArtifactUnauthorized(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	defer ts.Close()
+
+	err := client.DeleteArtifact("abc-123", "bad-token")
+	if err == nil {
+		t.Fatal("expected error for unauthorized")
+	}
+}
+
+func TestDownloadArtifact(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/download") {
+			link := DownloadLink{URI: "http://" + r.Host + "/file"}
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if r.URL.Path == "/file" {
+			w.Write([]byte("artifact-content"))
+			return
+		}
+		artifact := ArtifactInfo{ID: "id-1", Name: "test-art"}
+		json.NewEncoder(w).Encode(artifact)
+	})
+	defer ts.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "downloaded.mender")
+	err := client.DownloadArtifact("id-1", "token", outputPath)
+	if err != nil {
+		t.Fatalf("DownloadArtifact failed: %s", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %s", err)
+	}
+	if string(data) != "artifact-content" {
+		t.Errorf("got %q, want artifact-content", string(data))
+	}
+}
+
+func TestDownloadArtifactDefaultName(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/download") {
+			link := DownloadLink{URI: "http://" + r.Host + "/file"}
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if r.URL.Path == "/file" {
+			w.Write([]byte("data"))
+			return
+		}
+		artifact := ArtifactInfo{ID: "id-1", Name: "my-art"}
+		json.NewEncoder(w).Encode(artifact)
+	})
+	defer ts.Close()
+
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	err := client.DownloadArtifact("id-1", "token", "")
+	if err != nil {
+		t.Fatalf("DownloadArtifact failed: %s", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "my-art.mender")); err != nil {
+		t.Errorf("expected default-named file: %s", err)
+	}
+}
+
+func TestDownloadArtifactToTempDir(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/download") {
+			link := DownloadLink{URI: "http://" + r.Host + "/file"}
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if r.URL.Path == "/file" {
+			w.Write([]byte("temp-content"))
+			return
+		}
+		artifact := ArtifactInfo{ID: "id-1", Name: "tmp-art"}
+		json.NewEncoder(w).Encode(artifact)
+	})
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	path, err := client.DownloadArtifactToTempDir("id-1", "token", tmpDir)
+	if err != nil {
+		t.Fatalf("DownloadArtifactToTempDir failed: %s", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %s", err)
+	}
+	if string(data) != "temp-content" {
+		t.Errorf("got %q, want temp-content", string(data))
+	}
+}
+
+// paginatedHandler returns artifacts on page 1, empty on subsequent pages.
+func paginatedHandler(artifacts []ArtifactInfo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page != "" && page != "1" {
+			json.NewEncoder(w).Encode([]ArtifactInfo{})
+			return
+		}
+		json.NewEncoder(w).Encode(artifacts)
+	}
+}
+
+func TestDownloadArtifactToTempDirError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/download") {
+			link := DownloadLink{URI: "http://" + r.Host + "/file"}
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if r.URL.Path == "/file" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		artifact := ArtifactInfo{ID: "id-1", Name: "err-art"}
+		json.NewEncoder(w).Encode(artifact)
+	})
+	defer ts.Close()
+
+	_, err := client.DownloadArtifactToTempDir(
+		"id-1", "token", t.TempDir(),
+	)
+	if err == nil {
+		t.Fatal("expected error for failed download")
+	}
+}
+
+func TestDownloadArtifactNotFound(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "not found")
+	})
+	defer ts.Close()
+
+	err := client.DownloadArtifact(
+		"missing-id", "token", filepath.Join(t.TempDir(), "out"),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDeleteArtifactServerError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "server error")
+	})
+	defer ts.Close()
+
+	err := client.DeleteArtifact("id-1", "token")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestUploadArtifactServerError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "error")
+	})
+	defer ts.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "test.mender")
+	os.WriteFile(tmpFile, []byte("data"), 0600)
+
+	err := client.UploadArtifact(tmpFile, "token", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFindArtifactsByName(t *testing.T) {
+	allArtifacts := []ArtifactInfo{
+		{
+			ID: "id-1", Name: "release-v1",
+			DeviceTypesCompatible: []string{"rpi4"},
+		},
+		{
+			ID: "id-2", Name: "release-v1",
+			DeviceTypesCompatible: []string{"beaglebone"},
+		},
+		{ID: "id-3", Name: "other"},
+	}
+	ts, client := testServer(paginatedHandler(allArtifacts))
+	defer ts.Close()
+
+	matches, err := client.FindArtifactsByName("release-v1", "token")
+	if err != nil {
+		t.Fatalf("FindArtifactsByName failed: %s", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+}
+
+func TestFindArtifactsByNameNotFound(t *testing.T) {
+	ts, client := testServer(paginatedHandler([]ArtifactInfo{}))
+	defer ts.Close()
+
+	_, err := client.FindArtifactsByName("nonexistent", "token")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
+func TestFindArtifactByNameUnique(t *testing.T) {
+	allArtifacts := []ArtifactInfo{
+		{
+			ID: "id-1", Name: "unique-art",
+			DeviceTypesCompatible: []string{"rpi4"},
+		},
+		{ID: "id-2", Name: "other"},
+	}
+	ts, client := testServer(paginatedHandler(allArtifacts))
+	defer ts.Close()
+
+	art, err := client.FindArtifactByName("unique-art", "", "token")
+	if err != nil {
+		t.Fatalf("FindArtifactByName failed: %s", err)
+	}
+	if art.ID != "id-1" {
+		t.Errorf("got ID %q, want id-1", art.ID)
+	}
+}
+
+func TestFindArtifactByNameAmbiguous(t *testing.T) {
+	allArtifacts := []ArtifactInfo{
+		{
+			ID: "id-1", Name: "release",
+			DeviceTypesCompatible: []string{"rpi4"},
+		},
+		{
+			ID: "id-2", Name: "release",
+			DeviceTypesCompatible: []string{"beaglebone"},
+		},
+	}
+	ts, client := testServer(paginatedHandler(allArtifacts))
+	defer ts.Close()
+
+	_, err := client.FindArtifactByName("release", "", "token")
+	if err == nil {
+		t.Fatal("expected error for ambiguous name")
+	}
+	if !strings.Contains(err.Error(), "matches 2 artifacts") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestFindArtifactByNameWithDeviceType(t *testing.T) {
+	allArtifacts := []ArtifactInfo{
+		{
+			ID: "id-1", Name: "release",
+			DeviceTypesCompatible: []string{"rpi4"},
+		},
+		{
+			ID: "id-2", Name: "release",
+			DeviceTypesCompatible: []string{"beaglebone"},
+		},
+	}
+	ts, client := testServer(paginatedHandler(allArtifacts))
+	defer ts.Close()
+
+	art, err := client.FindArtifactByName(
+		"release", "beaglebone", "token",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if art.ID != "id-2" {
+		t.Errorf("got ID %q, want id-2", art.ID)
+	}
+}
+
+func TestFindArtifactByNameDeviceTypeNoMatch(t *testing.T) {
+	allArtifacts := []ArtifactInfo{
+		{
+			ID: "id-1", Name: "release",
+			DeviceTypesCompatible: []string{"rpi4"},
+		},
+	}
+	ts, client := testServer(paginatedHandler(allArtifacts))
+	defer ts.Close()
+
+	_, err := client.FindArtifactByName(
+		"release", "unknown-dt", "token",
+	)
+	if err == nil {
+		t.Fatal("expected error for no device type match")
+	}
+	if !strings.Contains(err.Error(), "none compatible") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestDownloadArtifactByName(t *testing.T) {
+	allArtifacts := []ArtifactInfo{
+		{ID: "id-1", Name: "my-art", Size: 100},
+	}
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/list") {
+			page := r.URL.Query().Get("page")
+			if page != "" && page != "1" {
+				json.NewEncoder(w).Encode([]ArtifactInfo{})
+				return
+			}
+			json.NewEncoder(w).Encode(allArtifacts)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/download") {
+			link := DownloadLink{URI: "http://" + r.Host + "/file"}
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if r.URL.Path == "/file" {
+			w.Write([]byte("by-name-content"))
+			return
+		}
+		json.NewEncoder(w).Encode(allArtifacts[0])
+	})
+	defer ts.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "out.mender")
+	err := client.DownloadArtifactByName(
+		"my-art", "", "token", outputPath,
+	)
+	if err != nil {
+		t.Fatalf("DownloadArtifactByName failed: %s", err)
+	}
+
+	data, _ := os.ReadFile(outputPath)
+	if string(data) != "by-name-content" {
+		t.Errorf("got %q, want by-name-content", string(data))
+	}
+}
+
+func TestFormatArtifactListEmpty(t *testing.T) {
+	result := FormatArtifactList(nil)
+	if result != "No artifacts found." {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestFormatArtifactList(t *testing.T) {
+	artifacts := []ArtifactInfo{
+		{
+			ID: "abc-123", Name: "test", Size: 1500,
+			Modified: "2026-01-01T00:00:00Z",
+		},
+	}
+	result := FormatArtifactList(artifacts)
+	if !strings.Contains(result, "abc-123") {
+		t.Errorf("expected ID in output: %s", result)
+	}
+	if !strings.Contains(result, "test") {
+		t.Errorf("expected name in output: %s", result)
+	}
+}
+
+func TestUploadArtifactMissingFile(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	defer ts.Close()
+
+	err := client.UploadArtifact("/nonexistent/file.mender", "token", "")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestUploadArtifactWithDescription(t *testing.T) {
+	var gotDesc bool
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseMultipartForm(10 << 20)
+		if err == nil && r.FormValue("description") == "my desc" {
+			gotDesc = true
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+	defer ts.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "test.mender")
+	os.WriteFile(tmpFile, []byte("data"), 0600)
+
+	err := client.UploadArtifact(tmpFile, "token", "my desc")
+	if err != nil {
+		t.Fatalf("UploadArtifact failed: %s", err)
+	}
+	if !gotDesc {
+		t.Error("description field not received by server")
+	}
+}
+
+func TestListArtifactsInvalidJSON(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "not-json")
+	})
+	defer ts.Close()
+
+	_, err := client.ListArtifacts("token", 1, 20)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestGetArtifactInvalidJSON(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "not-json")
+	})
+	defer ts.Close()
+
+	_, err := client.GetArtifact("id-1", "token")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestDownloadArtifactLinkError(t *testing.T) {
+	callCount := 0
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			json.NewEncoder(w).Encode(ArtifactInfo{
+				ID: "id-1", Name: "art",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "link error")
+	})
+	defer ts.Close()
+
+	err := client.DownloadArtifact(
+		"id-1", "token", filepath.Join(t.TempDir(), "out"),
+	)
+	if err == nil {
+		t.Fatal("expected error when download link fails")
+	}
+}
+
+func TestDownloadArtifactHTTPError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/download") {
+			link := DownloadLink{URI: "http://" + r.Host + "/file"}
+			json.NewEncoder(w).Encode(link)
+			return
+		}
+		if r.URL.Path == "/file" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		json.NewEncoder(w).Encode(ArtifactInfo{
+			ID: "id-1", Name: "art",
+		})
+	})
+	defer ts.Close()
+
+	err := client.DownloadArtifact(
+		"id-1", "token", filepath.Join(t.TempDir(), "out"),
+	)
+	if err == nil {
+		t.Fatal("expected error for forbidden download")
+	}
+}
+
+func TestDownloadLinkInvalidJSON(t *testing.T) {
+	callCount := 0
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			json.NewEncoder(w).Encode(ArtifactInfo{
+				ID: "id-1", Name: "art",
+			})
+			return
+		}
+		fmt.Fprint(w, "not-json")
+	})
+	defer ts.Close()
+
+	err := client.DownloadArtifact(
+		"id-1", "token", filepath.Join(t.TempDir(), "out"),
+	)
+	if err == nil {
+		t.Fatal("expected error for invalid link JSON")
+	}
+}
+
+func TestDownloadArtifactByNameError(t *testing.T) {
+	ts, client := testServer(paginatedHandler([]ArtifactInfo{}))
+	defer ts.Close()
+
+	err := client.DownloadArtifactByName(
+		"missing", "", "token", filepath.Join(t.TempDir(), "out"),
+	)
+	if err == nil {
+		t.Fatal("expected error for missing artifact")
+	}
+}
+
+func TestDownloadArtifactToTempDirGetError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "not found")
+	})
+	defer ts.Close()
+
+	_, err := client.DownloadArtifactToTempDir(
+		"missing-id", "token", t.TempDir(),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDownloadArtifactToTempDirLinkError(t *testing.T) {
+	callCount := 0
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			json.NewEncoder(w).Encode(ArtifactInfo{
+				ID: "id-1", Name: "art",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer ts.Close()
+
+	_, err := client.DownloadArtifactToTempDir(
+		"id-1", "token", t.TempDir(),
+	)
+	if err == nil {
+		t.Fatal("expected error when link fails")
+	}
+}
+
+func TestFormatArtifactListLongName(t *testing.T) {
+	artifacts := []ArtifactInfo{
+		{
+			ID:       "id-1",
+			Name:     "this-is-a-very-long-artifact-name-that-exceeds-thirty-chars",
+			Size:     999,
+			Modified: "2026-01-01T00:00:00.000000Z",
+		},
+	}
+	result := FormatArtifactList(artifacts)
+	if !strings.Contains(result, "...") {
+		t.Error("expected long name to be truncated with ...")
+	}
+	if !strings.Contains(result, "2026-01-01T00:00:00") {
+		t.Error("expected modified date to be truncated to 19 chars")
+	}
+}
+
+func TestFormatArtifactListWithType(t *testing.T) {
+	artifacts := []ArtifactInfo{
+		{
+			ID: "id-1", Name: "typed", Size: 5000,
+			Updates: []struct {
+				TypeInfo struct {
+					Type string `json:"type"`
+				} `json:"type_info"`
+			}{
+				{TypeInfo: struct {
+					Type string `json:"type"`
+				}{Type: "rootfs-image"}},
+			},
+		},
+	}
+	result := FormatArtifactList(artifacts)
+	if !strings.Contains(result, "rootfs-image") {
+		t.Errorf("expected type in output: %s", result)
+	}
+}
+
+func TestFindArtifactsByNameListError(t *testing.T) {
+	ts, client := testServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer ts.Close()
+
+	_, err := client.FindArtifactsByName("any", "token")
+	if err == nil {
+		t.Fatal("expected error when list fails")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{500, "500 B"},
+		{1500, "1.5 kB"},
+		{1500000, "1.5 MB"},
+		{1500000000, "1.5 GB"},
+	}
+	for _, tc := range cases {
+		got := formatBytes(tc.input)
+		if got != tc.want {
+			t.Errorf("formatBytes(%d) = %q, want %q",
+				tc.input, got, tc.want)
+		}
+	}
+}

--- a/cli/server/config.go
+++ b/cli/server/config.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+const configFileName = ".mender-clirc"
+
+// PersistServerToConfig ensures the JSON config file at path has a "server"
+// key set to server. It creates the file (and any missing parent directories)
+// if it does not exist. If the file already contains a "server" key, it is
+// left untouched and false is returned. Otherwise the key is written and true
+// is returned.
+func PersistServerToConfig(path string, server string) (bool, error) {
+	var content map[string]interface{}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, errors.Wrapf(err, "failed to read config file %s", path)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return false, errors.Wrapf(err, "failed to create directory for %s", path)
+		}
+		content = map[string]interface{}{}
+	} else {
+		if err := json.Unmarshal(data, &content); err != nil {
+			return false, errors.Wrapf(err, "failed to parse config file %s as JSON", path)
+		}
+		if _, exists := content["server"]; exists {
+			return false, nil
+		}
+	}
+
+	content["server"] = server
+
+	out, err := json.MarshalIndent(content, "", "  ")
+	if err != nil {
+		return false, errors.Wrap(err, "failed to encode config file content")
+	}
+	out = append(out, '\n')
+
+	if err := os.WriteFile(path, out, 0600); err != nil {
+		return false, errors.Wrapf(err, "failed to write config file %s", path)
+	}
+
+	return true, nil
+}
+
+// ResolveConfigFilePath returns the config file path to persist the server
+// to. If configFileUsed is non-empty (e.g. from a framework like viper), it
+// is returned as-is. Otherwise falls back to $HOME/.mender-clirc.
+func ResolveConfigFilePath(configFileUsed string) string {
+	if configFileUsed != "" {
+		return configFileUsed
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return configFileName
+	}
+
+	return filepath.Join(home, configFileName)
+}
+
+// LoadConfigServer reads the config file and returns the server URL if set.
+// Returns empty string if the file doesn't exist or has no "server" key.
+func LoadConfigServer(configFileUsed string) string {
+	path := ResolveConfigFilePath(configFileUsed)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	var content map[string]interface{}
+	if err := json.Unmarshal(data, &content); err != nil {
+		return ""
+	}
+
+	if s, ok := content["server"].(string); ok {
+		return s
+	}
+	return ""
+}

--- a/cli/server/config_test.go
+++ b/cli/server/config_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPersistServerToConfigCreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	written, err := PersistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !written {
+		t.Fatal("expected written=true for a new file")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat created file: %s", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("expected file mode 0600, got %o", perm)
+	}
+
+	content := readJSONFile(t, path)
+	if len(content) != 1 {
+		t.Errorf("expected 1 key, got %d: %v", len(content), content)
+	}
+	if content["server"] != "https://example.com" {
+		t.Errorf("expected server=https://example.com, got %v", content["server"])
+	}
+}
+
+func TestPersistServerToConfigCreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", ".mender-clirc")
+
+	written, err := PersistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !written {
+		t.Fatal("expected written=true for a new file")
+	}
+
+	content := readJSONFile(t, path)
+	if content["server"] != "https://example.com" {
+		t.Errorf("expected server=https://example.com, got %v", content["server"])
+	}
+}
+
+func TestPersistServerToConfigPreservesExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{"username": "alice", "password": "secret"}`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	written, err := PersistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !written {
+		t.Fatal("expected written=true when server key was absent")
+	}
+
+	content := readJSONFile(t, path)
+	if len(content) != 3 {
+		t.Errorf("expected 3 keys, got %d: %v", len(content), content)
+	}
+	if content["server"] != "https://example.com" {
+		t.Errorf("expected server=https://example.com, got %v", content["server"])
+	}
+	if content["username"] != "alice" {
+		t.Errorf("expected username=alice, got %v", content["username"])
+	}
+}
+
+func TestPersistServerToConfigDoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{"server": "https://staging.example.com", "username": "bob"}`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	written, err := PersistServerToConfig(path, "https://different.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if written {
+		t.Fatal("expected written=false when server key already exists")
+	}
+
+	content := readJSONFile(t, path)
+	if content["server"] != "https://staging.example.com" {
+		t.Errorf("expected server to remain unchanged, got %v", content["server"])
+	}
+}
+
+func TestPersistServerToConfigEmptyServerCounts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{"server": ""}`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	written, err := PersistServerToConfig(path, "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if written {
+		t.Fatal("expected written=false when server key is present (even if empty)")
+	}
+}
+
+func TestPersistServerToConfigMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+
+	original := []byte(`{not valid json`)
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %s", err)
+	}
+
+	_, err := PersistServerToConfig(path, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %s", err)
+	}
+	if string(data) != string(original) {
+		t.Errorf("expected file to remain unchanged, got %q", string(data))
+	}
+}
+
+func TestResolveConfigFilePath(t *testing.T) {
+	t.Run("explicit path returned as-is", func(t *testing.T) {
+		got := ResolveConfigFilePath("/etc/mender-cli/.mender-clirc")
+		if got != "/etc/mender-cli/.mender-clirc" {
+			t.Errorf("got %q, want /etc/mender-cli/.mender-clirc", got)
+		}
+	})
+
+	t.Run("empty falls back to home dir", func(t *testing.T) {
+		got := ResolveConfigFilePath("")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("no home dir available")
+		}
+		want := filepath.Join(home, ".mender-clirc")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestPersistServerToConfigReadError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+	os.Mkdir(path, 0700)
+
+	_, err := PersistServerToConfig(path, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error when path is a directory")
+	}
+}
+
+func TestResolveConfigFilePathNoHome(t *testing.T) {
+	got := ResolveConfigFilePath("")
+	if got == "" {
+		t.Error("expected non-empty path")
+	}
+}
+
+func TestLoadConfigServerMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+	os.WriteFile(path, []byte(`{not json`), 0600)
+
+	got := LoadConfigServer(path)
+	if got != "" {
+		t.Errorf("expected empty for malformed JSON, got %q", got)
+	}
+}
+
+func TestLoadConfigServerNonStringValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mender-clirc")
+	os.WriteFile(path, []byte(`{"server": 12345}`), 0600)
+
+	got := LoadConfigServer(path)
+	if got != "" {
+		t.Errorf("expected empty for non-string server, got %q", got)
+	}
+}
+
+func TestLoadConfigServer(t *testing.T) {
+	t.Run("returns server from config", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".mender-clirc")
+		os.WriteFile(path, []byte(`{"server": "https://my.server.io"}`), 0600)
+
+		got := LoadConfigServer(path)
+		if got != "https://my.server.io" {
+			t.Errorf("got %q, want https://my.server.io", got)
+		}
+	})
+
+	t.Run("returns empty for missing file", func(t *testing.T) {
+		got := LoadConfigServer("/nonexistent/path/.mender-clirc")
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("returns empty for no server key", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".mender-clirc")
+		os.WriteFile(path, []byte(`{"username": "alice"}`), 0600)
+
+		got := LoadConfigServer(path)
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func readJSONFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %s", path, err)
+	}
+	var content map[string]interface{}
+	if err := json.Unmarshal(data, &content); err != nil {
+		t.Fatalf("failed to parse JSON file %s: %s", path, err)
+	}
+	return content
+}


### PR DESCRIPTION
add artifact registry commands (login, push, pull, ls) in a framework-agnostic server client package that can be reused by other tools (e.g. mender-cli)

The cli/server package provides:
- Client: HTTP client for the Mender deployments API (login, upload, download, list artifacts, find by name with release disambiguation)
- Auth: token storage at ~/.cache/mender/authtoken (compatible with mender-cli)
- Config: server URL persistence to ~/.mender-clirc (ports the functionality from https://github.com/mendersoftware/mender-cli/pull/363) on login with a non-default --server, the server URL is persisted to the config file for subsequent commands
