### PR TITLE
fix(cli): resolve symlinks against their own directory when signing

### DIFF
--- a/cli/sign.go
+++ b/cli/sign.go
@@ -40,6 +40,11 @@ func signExisting(c *cli.Context) error {
 	}
 
 	artFile := c.Args().First()
+	artFile, err = filepath.EvalSymlinks(artFile)
+	if err != nil {
+		err = errors.Wrapf(err, "Can not resolve: %s", c.Args().First())
+		return cli.NewExitError(err, 1)
+	}
 	outputFile := artFile
 	if len(c.String("output-path")) > 0 {
 		outputFile = c.String("output-path")
@@ -59,29 +64,11 @@ func signExisting(c *cli.Context) error {
 	}
 	defer f.Close()
 
-	artFileStat, err := os.Lstat(artFile)
+	artFileStat, err := os.Stat(artFile)
 	if err != nil {
 		return cli.NewExitError("Could not get artifact file stat", 1)
 	}
 
-	if artFileStat.Mode()&os.ModeSymlink == os.ModeSymlink {
-		f.Close()
-		artFile, err = os.Readlink(artFile)
-		if err != nil {
-			return cli.NewExitError(err, 1)
-		}
-		outputFile = artFile
-		artFileStat, err = os.Stat(artFile)
-		if err != nil {
-			return cli.NewExitError("Could not get artifact file stat", 1)
-		}
-		f, err = os.Open(artFile)
-		if err != nil {
-			err = errors.Wrapf(err, "Can not open: %s", artFile)
-			return cli.NewExitError(err, 1)
-		}
-		defer f.Close()
-	}
 	err = CopyOwner(tFile, artFile)
 	if err != nil {
 		return cli.NewExitError("Could not set owner/group of signed artifact "+

--- a/cli/sign_test.go
+++ b/cli/sign_test.go
@@ -396,3 +396,141 @@ func TestSignViaSymlink(t *testing.T) {
 		filepath.Join(updateTestDir, "artifact.mender")})
 	assert.NoError(t, err)
 }
+
+func TestSignViaRelativeSymlink(t *testing.T) {
+	updateTestDir, _ := os.MkdirTemp("", "update")
+	defer os.RemoveAll(updateTestDir)
+
+	priv, pub, err := generateKeys()
+	assert.NoError(t, err)
+
+	err = WriteArtifact(updateTestDir, 2, "")
+	assert.NoError(t, err)
+
+	err = MakeFakeUpdateDir(updateTestDir,
+		[]TestDirEntry{
+			{
+				Path:    "private.key",
+				Content: priv,
+				IsDir:   false,
+			},
+			{
+				Path:    "public.key",
+				Content: pub,
+				IsDir:   false,
+			},
+		})
+	assert.NoError(t, err)
+
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NotEqual(t, cwd, updateTestDir)
+
+	symlink := filepath.Join(updateTestDir, "symlink")
+	err = os.Symlink("artifact.mender", symlink)
+	assert.NoError(t, err)
+
+	err = Run([]string{"mender-artifact", "sign",
+		"-k", filepath.Join(updateTestDir, "private.key"),
+		symlink})
+	assert.NoError(t, err)
+
+	// the original artifact got signed in place
+	err = Run([]string{"mender-artifact", "validate",
+		"-k", filepath.Join(updateTestDir, "public.key"),
+		filepath.Join(updateTestDir, "artifact.mender")})
+	assert.NoError(t, err)
+}
+
+func TestSignViaSymlinkChain(t *testing.T) {
+	updateTestDir, _ := os.MkdirTemp("", "update")
+	defer os.RemoveAll(updateTestDir)
+
+	priv, pub, err := generateKeys()
+	assert.NoError(t, err)
+
+	err = WriteArtifact(updateTestDir, 2, "")
+	assert.NoError(t, err)
+
+	err = MakeFakeUpdateDir(updateTestDir,
+		[]TestDirEntry{
+			{
+				Path:    "private.key",
+				Content: priv,
+				IsDir:   false,
+			},
+			{
+				Path:    "public.key",
+				Content: pub,
+				IsDir:   false,
+			},
+		})
+	assert.NoError(t, err)
+
+	link1 := filepath.Join(updateTestDir, "link1")
+	link2 := filepath.Join(updateTestDir, "link2")
+	err = os.Symlink("artifact.mender", link1)
+	assert.NoError(t, err)
+	err = os.Symlink("link1", link2)
+	assert.NoError(t, err)
+
+	err = Run([]string{"mender-artifact", "sign",
+		"-k", filepath.Join(updateTestDir, "private.key"),
+		link2})
+	assert.NoError(t, err)
+
+	err = Run([]string{"mender-artifact", "validate",
+		"-k", filepath.Join(updateTestDir, "public.key"),
+		filepath.Join(updateTestDir, "artifact.mender")})
+	assert.NoError(t, err)
+}
+
+func TestSignViaSymlinkWithOutputPath(t *testing.T) {
+	updateTestDir, _ := os.MkdirTemp("", "update")
+	defer os.RemoveAll(updateTestDir)
+
+	priv, pub, err := generateKeys()
+	assert.NoError(t, err)
+
+	err = WriteArtifact(updateTestDir, 2, "")
+	assert.NoError(t, err)
+
+	err = MakeFakeUpdateDir(updateTestDir,
+		[]TestDirEntry{
+			{
+				Path:    "private.key",
+				Content: priv,
+				IsDir:   false,
+			},
+			{
+				Path:    "public.key",
+				Content: pub,
+				IsDir:   false,
+			},
+		})
+	assert.NoError(t, err)
+
+	original, err := os.ReadFile(filepath.Join(updateTestDir, "artifact.mender"))
+	assert.NoError(t, err)
+
+	symlink := filepath.Join(updateTestDir, "symlink")
+	err = os.Symlink("artifact.mender", symlink)
+	assert.NoError(t, err)
+
+	// --output-path must be honored even when the input is a symlink
+	err = Run([]string{"mender-artifact", "sign",
+		"-k", filepath.Join(updateTestDir, "private.key"),
+		"-o", filepath.Join(updateTestDir, "artifact.mender.sig"),
+		symlink})
+	assert.NoError(t, err)
+
+	err = Run([]string{"mender-artifact", "validate",
+		"-k", filepath.Join(updateTestDir, "public.key"),
+		filepath.Join(updateTestDir, "artifact.mender.sig")})
+	assert.NoError(t, err)
+
+	// the original artifact is left untouched
+	afterSign, err := os.ReadFile(filepath.Join(updateTestDir, "artifact.mender"))
+	assert.NoError(t, err)
+	assert.Equal(t, original, afterSign)
+}


### PR DESCRIPTION
## What

`mender-artifact sign` fails on relative symlinks with `Could not get artifact file stat` whenever the process working directory is not the symlink's directory. This PR replaces the manual symlink handling in `signExisting()` with a single `filepath.EvalSymlinks` call on the input path.

## The bug

`signExisting()` resolved symlinks in userspace and got the resolution base wrong:

```go
artFile, err = os.Readlink(artFile) // raw link text, e.g. "core-image-...-20260714.mender"
artFileStat, err = os.Stat(artFile) // resolved against the process cwd, not the link's dir
```

`os.Readlink` returns the target exactly as stored in the link. When that target is relative, the subsequent `os.Stat` resolves it against the process working directory instead of the symlink's own directory.

### Example: signing a Yocto-built artifact

Yocto/meta-mender deploys artifacts as a versioned file plus a **relative** symlink:

```
$ ls -l tmp/deploy/images/raspberrypi4/
core-image-full-cmdline-raspberrypi4.mender -> core-image-full-cmdline-raspberrypi4-20260714120000.mender
core-image-full-cmdline-raspberrypi4-20260714120000.mender
```

Signing via the symlink from anywhere other than that directory fails:

```
$ cd ~/build   # anywhere that isn't the images/raspberrypi4 directory
$ mender-artifact sign \
      -k private.key \
      tmp/deploy/images/raspberrypi4/core-image-full-cmdline-raspberrypi4.mender
Could not get artifact file stat
```

`mender-artifact read` on the same path works. `mender artifact sign` works when running from the pwd of the symlink. The current workaround would be to canonicalise the path first, and sign that path instead.

## The fix

Resolve the input path once with `filepath.EvalSymlinks`.

Fixes that fall out of this:

* `-o` / `--output-path` is no longer silently overridden when the input is a symlink
* The temporary file is created in the resolved target's directory rather than the link's, so the final `os.Rename` stays on one filesystem.
* Chains of symlinks now work

## Tests

* `TestSignViaRelativeSymlink` — regression test for the scenario above: relative link target, cwd elsewhere. Fails with `Could not get artifact file stat` on the old code.
* `TestSignViaSymlinkChain` — a two-hop chain of relative symlinks.
* `TestSignViaSymlinkWithOutputPath` — `--output-path` is honoured for symlink inputs and the original artifact is left alone.

The existing `TestSignViaSymlink` (absolute link target) still passes and is kept as-is.

Ticket: None