### PR TITLE
fix(cli): Correct binary name in no-argument error messages

### DIFF
--- a/cli/modify.go
+++ b/cli/modify.go
@@ -42,7 +42,7 @@ func modifyArtifact(c *cli.Context) (err error) {
 
 	if c.NArg() == 0 {
 		return cli.NewExitError("Nothing specified, nothing will be modified. \n"+
-			"Maybe you wanted to say 'artifacts read <pathspec>'?", 1)
+			"Maybe you wanted to say 'mender-artifact modify <pathspec>'?", 1)
 	}
 
 	if _, err := os.Stat(c.Args().First()); err != nil && os.IsNotExist(err) {

--- a/cli/modify_existing_test.go
+++ b/cli/modify_existing_test.go
@@ -52,6 +52,13 @@ func copyFile(src, dst string) error {
 	return out.Close()
 }
 
+func TestModifyNoArgs(t *testing.T) {
+	err := Run([]string{"mender-artifact", "modify"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Nothing specified, nothing will be modified.")
+	assert.Contains(t, err.Error(), "mender-artifact modify <pathspec>")
+}
+
 func TestDebugfs(t *testing.T) {
 	tmp, err := os.MkdirTemp("", "mender-modify")
 	assert.NoError(t, err)

--- a/cli/read.go
+++ b/cli/read.go
@@ -244,7 +244,7 @@ func printUpdates(updatePayloads map[int]handlers.Installer, indentationLevel in
 func readArtifact(c *cli.Context) error {
 	if c.NArg() == 0 {
 		return cli.NewExitError("Nothing specified, nothing read. \nMaybe you wanted"+
-			" to say 'artifacts read <pathspec>'?", errArtifactInvalidParameters)
+			" to say 'mender-artifact read <pathspec>'?", errArtifactInvalidParameters)
 	}
 
 	f, err := os.Open(c.Args().First())

--- a/cli/read_test.go
+++ b/cli/read_test.go
@@ -39,6 +39,8 @@ func TestArtifactsRead(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(),
 		"Nothing specified, nothing read.")
+	assert.Contains(t, errors.Cause(err).Error(),
+		"mender-artifact read <pathspec>")
 
 	err = Run([]string{"mender-artifact", "read",
 		filepath.Join(updateTestDir, "artifact.mender")})

--- a/cli/sign.go
+++ b/cli/sign.go
@@ -27,7 +27,7 @@ import (
 func signExisting(c *cli.Context) error {
 	if c.NArg() == 0 {
 		return cli.NewExitError("Nothing specified, nothing signed. \nMaybe you wanted"+
-			" to say 'artifacts sign <pathspec>'?", 1)
+			" to say 'mender-artifact sign <pathspec>'?", 1)
 	}
 
 	privateKey, err := getKey(c)

--- a/cli/sign_test.go
+++ b/cli/sign_test.go
@@ -24,6 +24,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSignNoArgs(t *testing.T) {
+	err := Run([]string{"mender-artifact", "sign"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Nothing specified, nothing signed.")
+	assert.Contains(t, err.Error(), "mender-artifact sign <pathspec>")
+}
+
 func TestSignExistingV2(t *testing.T) {
 	// first create archive, that we will be able to read
 	updateTestDir, _ := os.MkdirTemp("", "update")

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -60,7 +60,7 @@ func validate(art io.Reader, key artifact.Verifier) error {
 func validateArtifact(c *cli.Context) error {
 	if c.NArg() == 0 {
 		return cli.NewExitError("Nothing specified, nothing validated. \nMaybe you wanted"+
-			" to say 'artifacts validate <pathspec>'?", errArtifactInvalidParameters)
+			" to say 'mender-artifact validate <pathspec>'?", errArtifactInvalidParameters)
 	}
 
 	key, err := getKey(c)

--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -147,6 +147,8 @@ func TestArtifactsValidateError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(),
 		"Nothing specified, nothing validated.")
+	assert.Contains(t, errors.Cause(err).Error(),
+		"mender-artifact validate <pathspec>")
 
 	fakeErrWriter.Reset()
 	err = Run([]string{"mender-artifact", "validate", "non-existing"})


### PR DESCRIPTION
Fixes the usage hint of read, validate, sign and modify commands ("mender-artifact" instead of "artifacts"), and the suggested subcommand in modify ("modify" instead of "read").

Assisted-by: OpenCode:claude-sonnet-4.6