### PR TITLE
Feat/delta image generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,7 @@ test:smoketests:linux:
       artifacts: true
   before_script:
     - !reference [.qa-common-network-apt-retry, before_script]
-    - apt-get update && apt-get install -q -y make liblzma-dev libssl-dev jq wget
+    - apt-get update && apt-get install -q -y make liblzma-dev libssl-dev jq wget xdelta3
     # yq no longer has a maintained debian repo so we fall back on the GitHub release as the source
     - wget -q https://github.com/mikefarah/yq/releases/download/v4.44.2/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
     - ./tests/test_sign_with_hsm/test_sign_with_hsm.sh --setup
@@ -162,6 +162,11 @@ test:smoketests:linux:
     - ./mender-artifact-linux validate test-rfs.mender
     - ./mender-artifact-linux validate --key tests/data/ec.pem tests/data/a0-signed-nitro.mender
     - test $(./mender-artifact-linux read --no-progress test-rfs.mender | yq eval -o json | jq -r '."Mender Artifact".Name') == "test"
+    - echo delta > test2.txt
+    - ./mender-artifact-linux write rootfs-image -c test -o test-rfs2.mender -n test2 -f test2.txt
+    - ./mender-artifact-linux write delta-image --from test-rfs.mender --to test-rfs2.mender -o test-delta.mender
+    - ./mender-artifact-linux read test-delta.mender
+    - ./mender-artifact-linux validate test-delta.mender
     - ./tests/test_compressions/test_supported_compressions.sh
 
 test:coverage:linux:
@@ -207,6 +212,7 @@ test:unit:linux:
     - !reference [.qa-common-network-apt-retry, before_script]
     - apt-get update && apt-get install --quiet --assume-yes
       git make bash dosfstools e2fsprogs gcc mtools musl-dev parted xz-utils libssl-dev
+      xdelta3
 
 test:unit:mac:
   extends: .test:unit
@@ -225,6 +231,8 @@ test:unit:mac:
     # correct and has not created valid links. This is the reason
     # why we are forcing to reinstall it
     - brew reinstall e2fsprogs
+    # xdelta3 is required by the `write delta-image` tests
+    - brew install xdelta
   after_script:
     # we want a clean environment on the runner for testing `brew install
     # mender-artifact` (which pulls `e2fsprogs`, among others, as a dependency)

--- a/apk-run-requirements.txt
+++ b/apk-run-requirements.txt
@@ -1,3 +1,4 @@
 libc6-compat
 xz
 libssl1.1
+xdelta3

--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -164,6 +164,7 @@ func getKey(c *cli.Context) (SigningKey, error) {
 			"rootfs-image":       true,
 			"module-image":       true,
 			"bootstrap-artifact": true,
+			"delta-image":        true,
 			"sign":               true,
 			"modify":             true,
 			"copy":               true,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -512,6 +512,109 @@ func getCliContext() *cli.App {
 
 	writeBootstrapArtifactCommand.Before = applyCompressionInCommand
 
+	//
+	// Delta between two rootfs-image Artifacts: delta-image
+	//
+	writeDeltaImageCommand := cli.Command{
+		Name:   "delta-image",
+		Action: writeDeltaImage,
+		Usage:  "Writes Mender artifact containing a binary delta between two rootfs images",
+		UsageText: "mender-artifact write delta-image --from <base.mender> --to <target.mender> " +
+			"[--output-path delta.mender]",
+		Description: "Generates a delta payload for the `" + deltaPayloadType + "` update " +
+			"module by running xdelta3 over the rootfs images of two `rootfs-image` " +
+			"Artifacts. Requires the `xdelta3` binary to be installed. The resulting " +
+			"Artifact only applies to a device which is currently running the base image.",
+	}
+
+	writeDeltaImageCommand.CustomHelpTemplate = CustomSubcommandHelpTemplate
+
+	writeDeltaImageCommand.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:     "from",
+			Usage:    "`FILE` path to the base (currently installed) rootfs-image Artifact.",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:     "to",
+			Usage:    "`FILE` path to the target (to be installed) rootfs-image Artifact.",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:  "output-path, o",
+			Usage: "Full path to output artifact file, '-' for stdout.",
+			Value: "delta.mender",
+		},
+		cli.StringFlag{
+			Name: "artifact-name, n",
+			Usage: "Name of the artifact. Defaults to the name of the target " +
+				"Artifact.",
+		},
+		cli.StringSliceFlag{
+			Name:  "device-type, t",
+			Usage: "DEPRECATED. Use --compatible-types instead.",
+		},
+		cli.StringSliceFlag{
+			Name: "compatible-types, c",
+			Usage: "Type of device(s) supported by the Artifact. Defaults to the " +
+				"compatible types of the target Artifact.",
+		},
+		cli.StringSliceFlag{
+			Name: decoderArgumentsFlag + ", D",
+			Usage: "Extra `ARGUMENTS` passed to xdelta3, both when generating the " +
+				"delta and, through the payload meta-data, when applying it on the " +
+				"device. Typically used to bound the memory the device needs, e.g. " +
+				"'-B524288000 -W150000 -P262144 -I62768'.",
+		},
+		cli.StringSliceFlag{
+			Name: "script, s",
+			Usage: "Full path to the state script(s), added to the ones " +
+				"inherited from the target Artifact. You can specify multiple " +
+				"scripts providing this parameter multiple times.",
+		},
+		cli.StringFlag{
+			Name:  "tmp",
+			Value: os.TempDir(),
+			Usage: "Provide custom file path for tmp directory.",
+		},
+		cli.BoolFlag{
+			Name:  "no-progress",
+			Usage: "Suppress the progressbar output",
+		},
+		compressionFlag,
+		privateKeyFlag,
+		gcpKMSKeyFlag,
+		vaultTransitKeyFlag,
+		signserverWorkerName,
+		azureKeyFlag,
+		/////////////////////////
+		// Version 3 specifics.//
+		/////////////////////////
+		artifactNameDepends,
+		artifactProvidesGroup,
+		artifactDependsGroups,
+		payloadDepends,
+		payloadProvides,
+		payloadMetaData,
+		clearsArtifactProvides,
+		noDefaultClearsArtifactProvides,
+		///////////////////////
+		// Software versions //
+		///////////////////////
+		softwareVersionNoDefault,
+		cli.StringFlag{
+			Name: softwareNameFlag,
+			Usage: "Name of the key to store the software version: rootfs-image.NAME.version," +
+				" instead of rootfs-image.version",
+		},
+		softwareVersionValue,
+		softwareFilesystem,
+		artifactSizeLimit,
+		artifactSizeWarnLimit,
+	}
+
+	writeDeltaImageCommand.Before = applyCompressionInCommand
+
 	writeCommand := cli.Command{
 		Name:     "write",
 		Usage:    "Writes artifact file.",
@@ -520,6 +623,7 @@ func getCliContext() *cli.App {
 			writeRootfsCommand,
 			writeModuleCommand,
 			writeBootstrapArtifactCommand,
+			writeDeltaImageCommand,
 		},
 	}
 

--- a/cli/delta.go
+++ b/cli/delta.go
@@ -1,0 +1,647 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+
+	"github.com/mendersoftware/mender-artifact/areader"
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/awriter"
+	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/mendersoftware/mender-artifact/utils"
+)
+
+const (
+	// deltaPayloadType is the name of the update module which applies the
+	// payload on the device.
+	deltaPayloadType = "mender-binary-delta"
+	// deltaAlgorithm is written to the payload meta-data so that the update
+	// module knows how to apply the delta.
+	deltaAlgorithm = "xdelta3"
+	deltaBinary    = "xdelta3"
+
+	standardChecksumKey = "rootfs-image.checksum"
+	legacyChecksumKey   = "rootfs_image_checksum"
+
+	decoderArgumentsFlag = "decoder-arguments"
+)
+
+// `--decoder-arguments` is meant for the xdelta3 memory options, which bound
+// the memory needed to apply the delta. They are also the only options which
+// are safe to splice into the encoder command line: anything else can change
+// the operation mode entirely (`-c`, for example, writes the delta to stdout
+// instead of the output file).
+var (
+	decoderArgumentRE      = regexp.MustCompile(`^-[BWPI][0-9]*$`)
+	decoderArgumentValueRE = regexp.MustCompile(`^[0-9]+$`)
+)
+
+// extractedArtifact holds everything the delta Artifact needs to inherit from
+// one of its two inputs.
+type extractedArtifact struct {
+	payloadFile  string
+	checksum     string
+	name         string
+	group        string
+	devices      []string
+	nameDepends  []string
+	groupDepends []string
+	provides     artifact.TypeInfoProvides
+	depends      artifact.TypeInfoDepends
+	clears       []string
+	metaData     map[string]interface{}
+	scripts      []string
+}
+
+func writeDeltaImage(c *cli.Context) error {
+	// Both `from` and `to` are declared as required flags, so they are
+	// guaranteed to be set by the time the action runs.
+	fromPath := c.String("from")
+	toPath := c.String("to")
+
+	if err := validateInput(c); err != nil {
+		Log.Error(err.Error())
+		return err
+	}
+
+	decoderArgs, err := deltaDecoderArguments(c)
+	if err != nil {
+		return cli.NewExitError(err.Error(), errArtifactInvalidParameters)
+	}
+
+	tmpDir, err := os.MkdirTemp(c.String("tmp"), "mender-delta-")
+	if err != nil {
+		return cli.NewExitError(
+			"can not create temporary directory: "+err.Error(),
+			errArtifactCreate,
+		)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	base, err := extractRootfsArtifact(fromPath, filepath.Join(tmpDir, "base"))
+	if err != nil {
+		return cli.NewExitError(
+			"can not read the base Artifact: "+err.Error(),
+			errArtifactInvalidParameters,
+		)
+	}
+
+	target, err := extractRootfsArtifact(toPath, filepath.Join(tmpDir, "target"))
+	if err != nil {
+		return cli.NewExitError(
+			"can not read the target Artifact: "+err.Error(),
+			errArtifactInvalidParameters,
+		)
+	}
+
+	// Validate the checksum contract before spending time on the delta.
+	if _, _, err := deltaChecksumKeys(base, target); err != nil {
+		return cli.NewExitError(err.Error(), errArtifactInvalidParameters)
+	}
+
+	// `rootfs_file_size` in the meta-data is the size of the uncompressed
+	// target rootfs image, not the size of the delta payload.
+	info, err := os.Stat(target.payloadFile)
+	if err != nil {
+		return cli.NewExitError(err.Error(), errArtifactCreate)
+	}
+
+	// Name the delta payload after the target rootfs image it reconstructs.
+	deltaPath := filepath.Join(tmpDir, filepath.Base(target.payloadFile)+".delta")
+
+	fmt.Fprintln(os.Stderr, "Generating delta...")
+	if err := generateDelta(
+		base.payloadFile, target.payloadFile, deltaPath, decoderArgs); err != nil {
+		return cli.NewExitError(err.Error(), errArtifactCreate)
+	}
+
+	return writeDeltaArtifact(c, base, target, deltaPath, info.Size(), decoderArgs)
+}
+
+// deltaDecoderArguments returns the extra xdelta3 arguments given with
+// `--decoder-arguments`. Each occurrence is split on whitespace so that both
+// `-D "-B10 -W20"` and `-D -B10 -D -W20` work. Only the xdelta3 memory
+// options are accepted, since the same arguments are spliced into the encoder
+// command line and recorded in the meta-data for the decoder.
+func deltaDecoderArguments(c *cli.Context) ([]string, error) {
+	var args []string
+	for _, arg := range c.StringSlice(decoderArgumentsFlag) {
+		args = append(args, strings.Fields(arg)...)
+	}
+	for i := 0; i < len(args); i++ {
+		if !decoderArgumentRE.MatchString(args[i]) {
+			return nil, fmt.Errorf(
+				"unsupported decoder argument %q: only the xdelta3 memory "+
+					"options -B, -W, -P and -I can be passed to the decoder "+
+					"on the device (e.g. '-B524288000')", args[i])
+		}
+		if len(args[i]) == 2 {
+			// A bare `-B`: the byte size has to follow as its own argument.
+			if i+1 >= len(args) || !decoderArgumentValueRE.MatchString(args[i+1]) {
+				return nil, fmt.Errorf(
+					"decoder argument %q is missing its byte size value", args[i])
+			}
+			i++
+		}
+	}
+	return args, nil
+}
+
+// rootfsExtractStore stores the payload files the same way dump does, but
+// rejects Artifacts with an augmented header: their augmented fields would
+// otherwise be silently dropped from the generated delta Artifact.
+type rootfsExtractStore struct {
+	dumpFileStore
+}
+
+func (s *rootfsExtractStore) NewUpdateStorer(
+	updateType *string,
+	payloadNum int,
+) (handlers.UpdateStorer, error) {
+	return s, nil
+}
+
+func (s *rootfsExtractStore) Initialize(artifactHeaders,
+	artifactAugmentedHeaders artifact.HeaderInfoer,
+	payloadHeaders handlers.ArtifactUpdateHeaders) error {
+
+	if artifactAugmentedHeaders != nil {
+		return errors.New("Artifacts with an augmented header are not supported")
+	}
+	return nil
+}
+
+func extractRootfsArtifact(artifactPath, extractDir string) (*extractedArtifact, error) {
+	f, err := os.Open(artifactPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "can not open Artifact")
+	}
+	defer f.Close()
+
+	scriptsDir := filepath.Join(extractDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+		return nil, errors.Wrap(err, "can not create the scripts directory")
+	}
+
+	var scriptFiles []string
+	ar := areader.NewReader(f)
+	ar.ScriptsReadCallback = func(r io.Reader, info os.FileInfo) error {
+		scriptPath := filepath.Join(scriptsDir, info.Name())
+		script, err := os.OpenFile(scriptPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+		if err != nil {
+			return err
+		}
+		defer script.Close()
+		if _, err := io.Copy(script, r); err != nil {
+			return err
+		}
+		scriptFiles = append(scriptFiles, scriptPath)
+		return nil
+	}
+
+	if err := ar.ReadArtifactHeaders(); err != nil {
+		return nil, errors.Wrap(err, "can not read Artifact headers")
+	}
+
+	if version := ar.GetInfo().Version; version < 3 {
+		return nil, fmt.Errorf(
+			"only format version 3 Artifacts carry the provides and depends "+
+				"a delta update is built on, got version %d", version)
+	}
+
+	if ar.IsSigned {
+		Log.Warnf("%s is signed, but the signature is not verified during "+
+			"delta generation", artifactPath)
+	}
+
+	handler, err := rootfsPayloadHandler(ar)
+	if err != nil {
+		return nil, err
+	}
+
+	filesDir := filepath.Join(extractDir, "files")
+	handler.SetUpdateStorerProducer(&rootfsExtractStore{
+		dumpFileStore{fileDir: filesDir, args: &[]string{}},
+	})
+	if err := ar.ReadArtifactData(); err != nil {
+		return nil, errors.Wrap(err, "can not read Artifact payload")
+	}
+
+	files, err := os.ReadDir(filesDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "can not list the extracted payload")
+	}
+	if len(files) != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one rootfs image in the payload, got %d", len(files))
+	}
+	payloadPath := filepath.Join(filesDir, files[0].Name())
+
+	checksum, err := sha256File(payloadPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "can not checksum the extracted payload")
+	}
+
+	extracted := &extractedArtifact{
+		payloadFile: payloadPath,
+		checksum:    checksum,
+		name:        ar.GetArtifactName(),
+		devices:     ar.GetCompatibleDevices(),
+		scripts:     scriptFiles,
+	}
+	inheritV3Metadata(ar, handler, extracted)
+
+	return extracted, nil
+}
+
+func rootfsPayloadHandler(ar *areader.Reader) (handlers.Installer, error) {
+	artHandlers := ar.GetHandlers()
+	if len(artHandlers) != 1 {
+		return nil, fmt.Errorf(
+			"delta generation requires an Artifact with exactly one payload, got %d",
+			len(artHandlers))
+	}
+
+	handler := artHandlers[0]
+	updateType := handler.GetUpdateType()
+	if updateType == nil || *updateType != "rootfs-image" {
+		typeName := "none"
+		if updateType != nil {
+			typeName = *updateType
+		}
+		return nil, fmt.Errorf(
+			"delta generation requires `rootfs-image` Artifacts, got %q", typeName)
+	}
+	return handler, nil
+}
+
+// inheritV3Metadata copies the header fields the delta Artifact carries over
+// from its input, so that provides such as `rootfs-image.version` survive the
+// delta update the same way they would survive a full rootfs update.
+func inheritV3Metadata(
+	ar *areader.Reader,
+	handler handlers.Installer,
+	extracted *extractedArtifact,
+) {
+	if provides := ar.GetArtifactProvides(); provides != nil {
+		extracted.name = provides.ArtifactName
+		extracted.group = provides.ArtifactGroup
+	}
+	if depends := ar.GetArtifactDepends(); depends != nil {
+		extracted.devices = depends.CompatibleDevices
+		extracted.nameDepends = depends.ArtifactName
+		extracted.groupDepends = depends.ArtifactGroup
+	}
+
+	extracted.provides = artifact.TypeInfoProvides{}
+	for k, v := range handler.GetUpdateOriginalProvides() {
+		extracted.provides[k] = v
+	}
+	// Values are `interface{}` because a single depends key may hold a list of
+	// accepted values, so they have to be copied as-is.
+	extracted.depends = artifact.TypeInfoDepends{}
+	for k, v := range handler.GetUpdateOriginalDepends() {
+		extracted.depends[k] = v
+	}
+	extracted.clears = handler.GetUpdateOriginalClearsProvides()
+	extracted.metaData = handler.GetUpdateOriginalMetaData()
+}
+
+// sha256File computes the same hex-encoded checksum
+// `writeRootfsImageChecksum` stores in the rootfs-image provides, so the
+// declared and the computed values are directly comparable.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	chk := artifact.NewWriterChecksum(io.Discard)
+	if _, err := io.Copy(chk, f); err != nil {
+		return "", err
+	}
+	return string(chk.Checksum()), nil
+}
+
+func generateDelta(baseFile, targetFile, outputFile string, decoderArgs []string) error {
+	xdelta3, err := utils.GetBinaryPath(deltaBinary)
+	if err != nil {
+		return errors.New("`xdelta3` was not found in the path, it is required to " +
+			"generate delta payloads. Install it with `apt install xdelta3`, " +
+			"`brew install xdelta`, or the equivalent for your platform")
+	}
+
+	// `-S lzma` pins the secondary compression instead of leaving it to the
+	// local xdelta3 defaults, so the payload does not depend on how the local
+	// xdelta3 was built: one without LZMA support fails here instead of
+	// silently producing a much larger delta.
+	//
+	// `-A` disables the application header, which would otherwise embed the
+	// rootfs image file names taken from inside the input Artifacts, and which
+	// makes the output depend on the temporary directory layout.
+	args := []string{"-e", "-S", "lzma", "-A"}
+	// The same tuning has to reach both ends: the encoder needs it to keep its
+	// windows within what the device can afford, and `decoder_arguments` in the
+	// meta-data passes it to the decoder on the device.
+	args = append(args, decoderArgs...)
+	args = append(args, "-s", baseFile, targetFile, outputFile)
+
+	cmd := exec.Command(xdelta3, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	// xdelta3 splices the contents of the `XDELTA` environment variable into
+	// its command line, which could override the options pinned above without
+	// leaving any trace in the Artifact, so the subprocess must not see it.
+	cmd.Env = make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "XDELTA=") {
+			cmd.Env = append(cmd.Env, e)
+		}
+	}
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "xdelta3 failed to generate the delta payload")
+	}
+	return nil
+}
+
+func writeDeltaArtifact(
+	c *cli.Context,
+	base, target *extractedArtifact,
+	deltaPath string,
+	rootfsSize int64,
+	decoderArgs []string,
+) error {
+	comp, err := artifact.NewCompressorFromId(c.GlobalString("compression"))
+	if err != nil {
+		return cli.NewExitError(
+			"compressor '"+c.GlobalString("compression")+"' is not supported: "+err.Error(),
+			1,
+		)
+	}
+
+	typeInfo, err := deltaTypeInfo(c, base, target)
+	if err != nil {
+		return cli.NewExitError(err.Error(), errArtifactInvalidParameters)
+	}
+
+	metaData, err := deltaMetaData(c, target, rootfsSize, decoderArgs)
+	if err != nil {
+		return err
+	}
+
+	// State scripts are inherited from the target Artifact, and `--script`
+	// adds to them.
+	scr, err := scripts(append(append([]string{}, target.scripts...),
+		c.StringSlice("script")...))
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	name := c.String("output-path")
+	var w io.Writer
+	if name == "-" {
+		w = os.Stdout
+	} else {
+		f, err := os.Create(name)
+		if err != nil {
+			return cli.NewExitError(
+				"can not create artifact file: "+err.Error(),
+				errArtifactCreate,
+			)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	aw, err := artifactWriter(c, comp, w, LatestFormatVersion)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	handler := handlers.NewModuleImage(deltaPayloadType)
+	if err := handler.SetUpdateFiles([]*handlers.DataFile{{Name: deltaPath}}); err != nil {
+		return cli.NewExitError(err.Error(), errArtifactCreate)
+	}
+
+	artifactName := c.String("artifact-name")
+	if artifactName == "" {
+		artifactName = target.name
+	}
+	devices := getCompatibleDevices(c)
+	if len(devices) == 0 {
+		devices = target.devices
+	}
+	group := c.String("provides-group")
+	if group == "" {
+		group = target.group
+	}
+	nameDepends := c.StringSlice("artifact-name-depends")
+	if len(nameDepends) == 0 {
+		nameDepends = target.nameDepends
+	}
+	groupDepends := c.StringSlice("depends-groups")
+	if len(groupDepends) == 0 {
+		groupDepends = target.groupDepends
+	}
+
+	if !c.Bool("no-progress") {
+		ctx, cancel := context.WithCancel(context.Background())
+		go reportProgress(ctx, aw.State)
+		defer cancel()
+		aw.ProgressWriter = utils.NewProgressWriter()
+	}
+
+	err = aw.WriteArtifact(&awriter.WriteArtifactArgs{
+		Format:  "mender",
+		Version: LatestFormatVersion,
+		Devices: devices,
+		Name:    artifactName,
+		Updates: &awriter.Updates{Updates: []handlers.Composer{handler}},
+		Scripts: scr,
+		Depends: &artifact.ArtifactDepends{
+			ArtifactName:      nameDepends,
+			CompatibleDevices: devices,
+			ArtifactGroup:     groupDepends,
+		},
+		Provides: &artifact.ArtifactProvides{
+			ArtifactName:  artifactName,
+			ArtifactGroup: group,
+		},
+		TypeInfoV3: typeInfo,
+		MetaData:   metaData,
+	})
+	if err != nil {
+		return cli.NewExitError(err.Error(), errArtifactCreate)
+	}
+
+	return checkArtifactSizeLimits(name, c)
+}
+
+// rootfsChecksumKey returns the spelling of the rootfs checksum key used by
+// the given provides, preferring the standard one, and whether any was found.
+func rootfsChecksumKey(provides artifact.TypeInfoProvides) (string, bool) {
+	if _, ok := provides[standardChecksumKey]; ok {
+		return standardChecksumKey, true
+	}
+	if _, ok := provides[legacyChecksumKey]; ok {
+		return legacyChecksumKey, true
+	}
+	return standardChecksumKey, false
+}
+
+// deltaChecksumKeys validates the rootfs checksum contract of the two input
+// Artifacts and returns the checksum key spelling of each. The two sides are
+// resolved independently: the depends side has to use the base Artifact's
+// spelling, because that is the key a device running the base image stores its
+// checksum under, while the provides side keeps the target Artifact's.
+func deltaChecksumKeys(base, target *extractedArtifact) (
+	string, string, error,
+) {
+	baseKey, ok := rootfsChecksumKey(base.provides)
+	if !ok {
+		return "", "", errors.New(
+			"the base Artifact does not provide a rootfs checksum (was it " +
+				"written with --no-checksum-provide?), so the generated delta " +
+				"could never match the provides of a device running it")
+	}
+	if declared := base.provides[baseKey]; declared != base.checksum {
+		return "", "", fmt.Errorf(
+			"the base Artifact provides `%s: %s`, but its rootfs image "+
+				"checksums to %s", baseKey, declared, base.checksum)
+	}
+
+	targetKey, ok := rootfsChecksumKey(target.provides)
+	if ok {
+		if declared := target.provides[targetKey]; declared != target.checksum {
+			return "", "", fmt.Errorf(
+				"the target Artifact provides `%s: %s`, but its rootfs image "+
+					"checksums to %s", targetKey, declared, target.checksum)
+		}
+	}
+	return baseKey, targetKey, nil
+}
+
+// deltaTypeInfo builds the payload type-info. The base layer is inherited from
+// the target Artifact, the shared `--provides`/`--depends`/`--software-*`
+// flags overlay it, and the rootfs checksum contract is written last: the
+// payload provides the target rootfs and depends on the base rootfs being the
+// one currently installed.
+func deltaTypeInfo(
+	c *cli.Context,
+	base, target *extractedArtifact,
+) (*artifact.TypeInfoV3, error) {
+	typeInfo, _, err := makeTypeInfo(c, deltaPayloadType)
+	if err != nil {
+		return nil, err
+	}
+
+	provides := artifact.TypeInfoProvides{}
+	for k, v := range target.provides {
+		provides[k] = v
+	}
+	for k, v := range typeInfo.ArtifactProvides {
+		provides[k] = v
+	}
+	// Values are `interface{}` because a single depends key may hold a list of
+	// accepted values, so they have to be copied as-is.
+	depends := artifact.TypeInfoDepends{}
+	for k, v := range target.depends {
+		depends[k] = v
+	}
+	for k, v := range typeInfo.ArtifactDepends {
+		depends[k] = v
+	}
+
+	baseKey, targetKey, err := deltaChecksumKeys(base, target)
+	if err != nil {
+		return nil, err
+	}
+
+	// The checksums are the delta contract, always computed from the two
+	// payloads, so they win over inherited and `--provides`/`--depends` given
+	// values.
+	delete(depends, standardChecksumKey)
+	delete(depends, legacyChecksumKey)
+	provides[targetKey] = target.checksum
+	depends[baseKey] = base.checksum
+
+	// makeTypeInfo already collected the command line clears plus the same
+	// defaults `write rootfs-image` uses, since a delta replaces the whole
+	// rootfs. The target's own clears are merged in on top, so that nothing
+	// the target Artifact would have cleared survives a delta update to it.
+	clears := typeInfo.ClearsArtifactProvides
+	if !c.Bool(noDefaultClearsProvidesFlag) {
+		clears = mergeUniqueStrings(clears, target.clears)
+	}
+
+	typeInfo.ArtifactProvides = provides
+	typeInfo.ArtifactDepends = depends
+	typeInfo.ClearsArtifactProvides = clears
+	return typeInfo, nil
+}
+
+func mergeUniqueStrings(lists ...[]string) []string {
+	var merged []string
+	seen := map[string]bool{}
+	for _, list := range lists {
+		for _, v := range list {
+			if !seen[v] {
+				seen[v] = true
+				merged = append(merged, v)
+			}
+		}
+	}
+	return merged
+}
+
+// deltaMetaData layers the meta-data file given with `--meta-data` over the
+// meta-data inherited from the target Artifact, then sets the keys which
+// describe the delta payload.
+func deltaMetaData(
+	c *cli.Context,
+	target *extractedArtifact,
+	rootfsSize int64,
+	decoderArgs []string,
+) (map[string]interface{}, error) {
+	metaData := map[string]interface{}{}
+	for k, v := range target.metaData {
+		metaData[k] = v
+	}
+	userMetaData, _, err := makeMetaData(c)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range userMetaData {
+		metaData[k] = v
+	}
+	metaData["rootfs_file_size"] = rootfsSize
+	metaData["delta_algorithm"] = deltaAlgorithm
+	if len(decoderArgs) > 0 {
+		metaData["decoder_arguments"] = decoderArgs
+	}
+	return metaData, nil
+}

--- a/cli/delta_test.go
+++ b/cli/delta_test.go
@@ -1,0 +1,535 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mendersoftware/mender-artifact/areader"
+	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/mendersoftware/mender-artifact/utils"
+)
+
+// deltaTestInputs writes two rootfs images which differ only in a trailing
+// block, packs each of them into a `rootfs-image` Artifact, and returns the
+// paths to the images and the Artifacts.
+type deltaTestInputs struct {
+	baseImage      string
+	targetImage    string
+	baseArtifact   string
+	targetArtifact string
+}
+
+func makeDeltaTestInputs(t *testing.T, dir string) deltaTestInputs {
+	in := deltaTestInputs{
+		baseImage:      filepath.Join(dir, "rootfs-v1.ext4"),
+		targetImage:    filepath.Join(dir, "rootfs-v2.ext4"),
+		baseArtifact:   filepath.Join(dir, "base.mender"),
+		targetArtifact: filepath.Join(dir, "target.mender"),
+	}
+
+	shared := bytes.Repeat([]byte("shared rootfs content, compresses well\n"), 512)
+	require.NoError(t, os.WriteFile(in.baseImage, shared, 0644))
+	require.NoError(t, os.WriteFile(in.targetImage,
+		append(shared, []byte("and something only the new image has\n")...), 0644))
+
+	require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+		"-c", "mydevice", "-n", "release-v1", "-f", in.baseImage,
+		"-o", in.baseArtifact, "--no-progress"}))
+	require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+		"-c", "mydevice", "-n", "release-v2", "-f", in.targetImage,
+		"-o", in.targetArtifact, "--no-progress"}))
+
+	return in
+}
+
+// readArtifactPayload reads the Artifact headers, extracts the single payload
+// into extractDir and returns the reader, the payload handler and the path to
+// the extracted file.
+func readArtifactPayload(
+	t *testing.T,
+	artifactPath, extractDir string,
+) (*areader.Reader, handlers.Installer, string) {
+	f, err := os.Open(artifactPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	ar := areader.NewReader(f)
+	require.NoError(t, ar.ReadArtifactHeaders())
+
+	artHandlers := ar.GetHandlers()
+	require.Len(t, artHandlers, 1)
+	handler := artHandlers[0]
+
+	handler.SetUpdateStorerProducer(&dumpFileStore{fileDir: extractDir, args: &[]string{}})
+	require.NoError(t, ar.ReadArtifactData())
+
+	files, err := os.ReadDir(extractDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	return ar, handler, filepath.Join(extractDir, files[0].Name())
+}
+
+func requireXdelta3(t *testing.T) string {
+	path, err := utils.GetBinaryPath("xdelta3")
+	if err != nil {
+		t.Skip("xdelta3 is not installed, skipping delta Artifact test")
+	}
+	return path
+}
+
+func TestWriteDeltaImage(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	baseChecksum, err := sha256File(in.baseImage)
+	require.NoError(t, err)
+	targetChecksum, err := sha256File(in.targetImage)
+	require.NoError(t, err)
+	targetInfo, err := os.Stat(in.targetImage)
+	require.NoError(t, err)
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress"}))
+
+	deltaPayload := filepath.Join(tmpdir, "extracted")
+	ar, handler, payloadPath := readArtifactPayload(t, deltaArtifact, deltaPayload)
+
+	// The delta Artifact identifies itself as the target: same name and the
+	// same compatible devices, so it is a drop-in replacement for it.
+	assert.Equal(t, "release-v2", ar.GetArtifactName())
+	assert.Equal(t, []string{"mydevice"}, ar.GetCompatibleDevices())
+
+	require.NotNil(t, handler.GetUpdateType())
+	assert.Equal(t, "mender-binary-delta", *handler.GetUpdateType())
+
+	// Provides the target rootfs, depends on the base rootfs being the one
+	// currently installed, and inherits the target's other provides.
+	assert.Equal(t, map[string]string{
+		"rootfs-image.checksum": targetChecksum,
+		"rootfs-image.version":  "release-v2",
+	}, map[string]string(handler.GetUpdateOriginalProvides()))
+	assert.Equal(t, map[string]interface{}{
+		"rootfs-image.checksum": baseChecksum,
+	}, map[string]interface{}(handler.GetUpdateOriginalDepends()))
+
+	// A delta replaces the whole rootfs, so it has to clear the same provides
+	// a full rootfs-image update clears.
+	assert.Equal(t, []string{
+		"artifact_group",
+		"rootfs_image_checksum",
+		"rootfs-image.*",
+	}, handler.GetUpdateOriginalClearsProvides())
+
+	// The meta-data which describes how to apply the payload. The size is the
+	// uncompressed target rootfs, not the delta.
+	assert.Equal(t, map[string]interface{}{
+		"delta_algorithm":  "xdelta3",
+		"rootfs_file_size": float64(targetInfo.Size()),
+	}, handler.GetUpdateOriginalMetaData())
+
+	files := handler.GetUpdateFiles()
+	require.Len(t, files, 1)
+	assert.Equal(t, "rootfs-v2.ext4.delta", files[0].Name)
+	assert.Less(t, files[0].Size, targetInfo.Size(),
+		"the delta should be smaller than the image it reconstructs")
+
+	assert.Equal(t, payloadPath, filepath.Join(deltaPayload, "rootfs-v2.ext4.delta"))
+}
+
+// TestWriteDeltaImageApplies is the contract that actually matters: feeding
+// the generated payload and the base image to the xdelta3 decoder has to
+// reproduce the target image byte for byte.
+func TestWriteDeltaImageApplies(t *testing.T) {
+	xdelta3 := requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress"}))
+
+	_, _, payloadPath := readArtifactPayload(t, deltaArtifact, filepath.Join(tmpdir, "extracted"))
+
+	applied := filepath.Join(tmpdir, "applied.ext4")
+	out, err := exec.Command(
+		xdelta3, "-d", "-s", in.baseImage, payloadPath, applied).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	appliedContent, err := os.ReadFile(applied)
+	require.NoError(t, err)
+	targetContent, err := os.ReadFile(in.targetImage)
+	require.NoError(t, err)
+	assert.Equal(t, targetContent, appliedContent)
+}
+
+// TestWriteDeltaImageDecoderArguments checks that the xdelta3 tuning is
+// recorded in the meta-data, from where it reaches the decoder when the delta
+// is applied on the device.
+func TestWriteDeltaImageDecoderArguments(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress",
+		// One flag given as a quoted group and one on its own, both spellings
+		// have to end up as separate arguments.
+		"-D", "-B10485760 -W1048576", "-D", "-P262144"}))
+
+	_, handler, _ := readArtifactPayload(t, deltaArtifact, filepath.Join(tmpdir, "extracted"))
+
+	assert.Equal(t, []interface{}{"-B10485760", "-W1048576", "-P262144"},
+		handler.GetUpdateOriginalMetaData()["decoder_arguments"])
+}
+
+func TestWriteDeltaImageSigned(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	privateKey := filepath.Join(tmpdir, "private.key")
+	require.NoError(t, os.WriteFile(privateKey, []byte(testPrivateKey), 0644))
+	publicKey := filepath.Join(tmpdir, "public.key")
+	require.NoError(t, os.WriteFile(publicKey, []byte(testPublicKey), 0644))
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress",
+		"-k", privateKey, "--compression", "lzma"}))
+
+	require.NoError(t, Run([]string{"mender-artifact", "validate",
+		"-k", publicKey, deltaArtifact}))
+}
+
+func TestWriteDeltaImageErrors(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	payload := filepath.Join(tmpdir, "update.ext4")
+	require.NoError(t, os.WriteFile(payload, []byte("some payload"), 0644))
+
+	moduleArtifact := filepath.Join(tmpdir, "module.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "module-image",
+		"-c", "mydevice", "-n", "module-v1", "-T", "testType", "-f", payload,
+		"-o", moduleArtifact, "--no-progress"}))
+
+	rootfsArtifact := filepath.Join(tmpdir, "rootfs.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+		"-c", "mydevice", "-n", "rootfs-v1", "-f", payload,
+		"-o", rootfsArtifact, "--no-progress"}))
+
+	out := filepath.Join(tmpdir, "delta.mender")
+
+	t.Run("missing --to", func(t *testing.T) {
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", rootfsArtifact, "-o", out, "--no-progress"})
+		assert.Error(t, err)
+	})
+
+	t.Run("base is not a rootfs-image", func(t *testing.T) {
+		requireXdelta3(t)
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", moduleArtifact, "--to", rootfsArtifact,
+			"-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires `rootfs-image` Artifacts")
+	})
+
+	t.Run("target is not a rootfs-image", func(t *testing.T) {
+		requireXdelta3(t)
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", rootfsArtifact, "--to", moduleArtifact,
+			"-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires `rootfs-image` Artifacts")
+	})
+
+	t.Run("base does not exist", func(t *testing.T) {
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", filepath.Join(tmpdir, "nope.mender"), "--to", rootfsArtifact,
+			"-o", out, "--no-progress"})
+		assert.Error(t, err)
+	})
+
+	t.Run("format version 2 input", func(t *testing.T) {
+		v2Artifact := filepath.Join(tmpdir, "v2.mender")
+		require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+			"-c", "mydevice", "-n", "rootfs-v2fmt", "-f", payload, "-v", "2",
+			"-o", v2Artifact, "--no-progress"}))
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", v2Artifact, "--to", rootfsArtifact,
+			"-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "version 3")
+	})
+
+	t.Run("base without a checksum provide", func(t *testing.T) {
+		noChecksum := filepath.Join(tmpdir, "nochecksum.mender")
+		require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+			"-c", "mydevice", "-n", "rootfs-nochk", "-f", payload,
+			"--no-checksum-provide", "-o", noChecksum, "--no-progress"}))
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", noChecksum, "--to", rootfsArtifact,
+			"-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rootfs checksum")
+	})
+
+	t.Run("unsupported decoder argument", func(t *testing.T) {
+		// `-c` would make the encoder dump the delta to stdout, so anything
+		// outside the xdelta3 memory options has to be rejected up front.
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", rootfsArtifact, "--to", rootfsArtifact,
+			"-o", out, "-D", "-c", "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported decoder argument")
+	})
+
+	t.Run("decoder argument without its value", func(t *testing.T) {
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", rootfsArtifact, "--to", rootfsArtifact,
+			"-o", out, "-D", "-B", "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "byte size")
+	})
+
+	t.Run("device-type and compatible-types conflict", func(t *testing.T) {
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", rootfsArtifact, "--to", rootfsArtifact,
+			"-t", "somedevice", "-c", "otherdevice",
+			"-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("whitespace in artifact-name", func(t *testing.T) {
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", rootfsArtifact, "--to", rootfsArtifact,
+			"-n", "two words", "-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "whitespace")
+	})
+
+	t.Run("augmented input", func(t *testing.T) {
+		augmentPayload := filepath.Join(tmpdir, "augment.ext4")
+		require.NoError(t, os.WriteFile(augmentPayload, []byte("augment payload"), 0644))
+		augmented := filepath.Join(tmpdir, "augmented.mender")
+		require.NoError(t, Run([]string{"mender-artifact", "write", "module-image",
+			"-c", "mydevice", "-n", "augmented-v1", "-T", "rootfs-image",
+			"-f", payload, "--augment-type", "rootfs-image",
+			"--augment-file", augmentPayload,
+			"-o", augmented, "--no-progress"}))
+		err := Run([]string{"mender-artifact", "write", "delta-image",
+			"--from", augmented, "--to", rootfsArtifact,
+			"-o", out, "--no-progress"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "augmented")
+	})
+}
+
+// TestWriteDeltaImageChecksumKeySpellings: the two sides of the checksum
+// contract are resolved independently. A device running a legacy base image
+// stores its checksum under `rootfs_image_checksum`, so that is the key the
+// depends has to use, while the provides keep the target's standard spelling.
+func TestWriteDeltaImageChecksumKeySpellings(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	// Rewrite the base as a legacy Artifact.
+	require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+		"-c", "mydevice", "-n", "release-v1", "-f", in.baseImage,
+		"-o", in.baseArtifact, "--legacy-rootfs-image-checksum", "--no-progress"}))
+
+	baseChecksum, err := sha256File(in.baseImage)
+	require.NoError(t, err)
+	targetChecksum, err := sha256File(in.targetImage)
+	require.NoError(t, err)
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress"}))
+
+	_, handler, _ := readArtifactPayload(t, deltaArtifact, filepath.Join(tmpdir, "extracted"))
+
+	provides := map[string]string(handler.GetUpdateOriginalProvides())
+	assert.Equal(t, targetChecksum, provides["rootfs-image.checksum"])
+	assert.NotContains(t, provides, "rootfs_image_checksum")
+
+	assert.Equal(t, map[string]interface{}{
+		"rootfs_image_checksum": baseChecksum,
+	}, map[string]interface{}(handler.GetUpdateOriginalDepends()))
+}
+
+// TestWriteDeltaImageOverrides: the shared payload flags overlay what is
+// inherited from the target Artifact, and `--clears-provides` adds to the
+// defaults instead of replacing them, like it does for the other write
+// commands.
+func TestWriteDeltaImageOverrides(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	metaFile := filepath.Join(tmpdir, "meta.json")
+	require.NoError(t, os.WriteFile(metaFile, []byte(`{"custom_meta": "yes"}`), 0644))
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress",
+		"-n", "delta-name",
+		"--software-version", "v2.override",
+		"-p", "custom.key:custom-value",
+		"-d", "custom.dep:dep-value",
+		"-m", metaFile,
+		"--clears-provides", "custom.*"}))
+
+	ar, handler, _ := readArtifactPayload(t, deltaArtifact, filepath.Join(tmpdir, "extracted"))
+
+	assert.Equal(t, "delta-name", ar.GetArtifactName())
+
+	provides := map[string]string(handler.GetUpdateOriginalProvides())
+	assert.Equal(t, "custom-value", provides["custom.key"])
+	// An explicit --software-version overrides the version inherited from the
+	// target Artifact, but the artifact name alone does not.
+	assert.Equal(t, "v2.override", provides["rootfs-image.version"])
+
+	depends := map[string]interface{}(handler.GetUpdateOriginalDepends())
+	assert.Equal(t, "dep-value", depends["custom.dep"])
+
+	clears := handler.GetUpdateOriginalClearsProvides()
+	assert.Contains(t, clears, "custom.*")
+	assert.Contains(t, clears, "artifact_group")
+	assert.Contains(t, clears, "rootfs_image_checksum")
+	assert.Contains(t, clears, "rootfs-image.*")
+
+	metaData := handler.GetUpdateOriginalMetaData()
+	assert.Equal(t, "yes", metaData["custom_meta"])
+	assert.Equal(t, "xdelta3", metaData["delta_algorithm"])
+}
+
+// TestWriteDeltaImageScripts: state scripts are inherited from the target
+// Artifact, and `--script` adds to them.
+func TestWriteDeltaImageScripts(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	inheritedScript := filepath.Join(tmpdir, "ArtifactInstall_Enter_01")
+	require.NoError(t, os.WriteFile(inheritedScript, []byte("#!/bin/sh\ntrue\n"), 0755))
+	addedScript := filepath.Join(tmpdir, "ArtifactCommit_Leave_01")
+	require.NoError(t, os.WriteFile(addedScript, []byte("#!/bin/sh\ntrue\n"), 0755))
+
+	// Rewrite the target with a state script attached.
+	require.NoError(t, Run([]string{"mender-artifact", "write", "rootfs-image",
+		"-c", "mydevice", "-n", "release-v2", "-f", in.targetImage,
+		"-o", in.targetArtifact, "-s", inheritedScript, "--no-progress"}))
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	require.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "-s", addedScript, "--no-progress"}))
+
+	f, err := os.Open(deltaArtifact)
+	require.NoError(t, err)
+	defer f.Close()
+	ar := areader.NewReader(f)
+	var scriptNames []string
+	ar.ScriptsReadCallback = func(r io.Reader, info os.FileInfo) error {
+		scriptNames = append(scriptNames, info.Name())
+		return nil
+	}
+	require.NoError(t, ar.ReadArtifactHeaders())
+
+	assert.Contains(t, scriptNames, "ArtifactInstall_Enter_01")
+	assert.Contains(t, scriptNames, "ArtifactCommit_Leave_01")
+}
+
+// TestWriteDeltaImageIgnoresXdeltaEnv: xdelta3 splices the contents of the
+// XDELTA environment variable into its command line, which could silently
+// override the pinned encoder options, so `write delta-image` must shield the
+// subprocess from it.
+func TestWriteDeltaImageIgnoresXdeltaEnv(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	// If this leaked through to the subprocess, xdelta3 would exit non-zero.
+	t.Setenv("XDELTA", "--not-a-valid-option")
+
+	deltaArtifact := filepath.Join(tmpdir, "delta.mender")
+	assert.NoError(t, Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", deltaArtifact, "--no-progress"}))
+}
+
+// TestWriteDeltaImageStdout: `-o -` streams the Artifact to stdout instead of
+// creating a file named `-`.
+func TestWriteDeltaImageStdout(t *testing.T) {
+	requireXdelta3(t)
+
+	tmpdir := t.TempDir()
+	in := makeDeltaTestInputs(t, tmpdir)
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&buf, r)
+		done <- copyErr
+	}()
+
+	runErr := Run([]string{"mender-artifact", "write", "delta-image",
+		"--from", in.baseArtifact, "--to", in.targetArtifact,
+		"-o", "-", "--no-progress"})
+	w.Close()
+	os.Stdout = oldStdout
+	require.NoError(t, <-done)
+	require.NoError(t, runErr)
+
+	assert.NotZero(t, buf.Len(), "the Artifact should have been written to stdout")
+	_, err = os.Stat("-")
+	assert.True(t, os.IsNotExist(err), "a file named '-' must not be created")
+}

--- a/cli/write.go
+++ b/cli/write.go
@@ -85,7 +85,7 @@ func getCompatibleDevices(c *cli.Context) []string {
 func validateInput(c *cli.Context) error {
 	// Version 2 and 3 validation.
 	fileMissing := false
-	if c.Command.Name != "bootstrap-artifact" {
+	if c.Command.Name != "bootstrap-artifact" && c.Command.Name != "delta-image" {
 		if len(c.String("file")) == 0 {
 			fileMissing = true
 		}
@@ -105,12 +105,16 @@ func validateInput(c *cli.Context) error {
 		)
 	}
 
-	if !hasDeviceType && !hasCompatibleTypes ||
-		len(c.String("artifact-name")) == 0 || fileMissing {
-		return cli.NewExitError(
-			"must provide `compatible-types`, `artifact-name` and `file`",
-			errArtifactInvalidParameters,
-		)
+	// `delta-image` inherits the artifact name, the compatible devices and
+	// the payload from its input Artifacts, so none of them are required.
+	if c.Command.Name != "delta-image" {
+		if !hasDeviceType && !hasCompatibleTypes ||
+			len(c.String("artifact-name")) == 0 || fileMissing {
+			return cli.NewExitError(
+				"must provide `compatible-types`, `artifact-name` and `file`",
+				errArtifactInvalidParameters,
+			)
+		}
 	}
 	if len(strings.Fields(c.String("artifact-name"))) > 1 {
 		// check for whitespace in artifact-name
@@ -637,6 +641,11 @@ func applySoftwareVersionToTypeInfoProvides(
 	}
 	softwareVersion := ctx.String(softwareVersionFlag)
 	noDefaultSoftwareVersion := ctx.Bool(noDefaultSoftwareVersionFlag)
+	if ctx.Command.Name == "delta-image" {
+		// The version provides are inherited from the target Artifact, so no
+		// defaults are derived; explicit --software-* flags still apply.
+		noDefaultSoftwareVersion = true
+	}
 	if softwareVersionMapping := getSoftwareVersion(
 		artifactName,
 		softwareFilesystem,
@@ -695,7 +704,10 @@ func makeClearsArtifactProvides(ctx *cli.Context) ([]string, error) {
 	var softwareName string
 	if len(ctx.String("software-name")) > 0 {
 		softwareName = ctx.String("software-name") + "."
-	} else if ctx.Command.Name == "rootfs-image" {
+	} else if ctx.Command.Name == "rootfs-image" ||
+		ctx.Command.Name == "delta-image" {
+		// A delta payload replaces the whole rootfs, so it clears the same
+		// provides a full rootfs-image update clears.
 		softwareName = ""
 		// "rootfs_image_checksum" is included for legacy
 		// reasons. Previously, "rootfs_image_checksum" was the name

--- a/deb-requirements.txt
+++ b/deb-requirements.txt
@@ -1,2 +1,3 @@
 liblzma-dev
 libssl-dev
+xdelta3

--- a/tests-acceptance-mac/ma-write-help-text.golden
+++ b/tests-acceptance-mac/ma-write-help-text.golden
@@ -6,6 +6,7 @@ USAGE:
 
 COMMANDS:
    bootstrap-artifact  Writes Mender bootstrap artifact containing empty payload
+   delta-image         Writes Mender artifact containing a binary delta between two rootfs images
    module-image        Writes Mender artifact for an update module
    rootfs-image        Writes Mender artifact containing rootfs image
 


### PR DESCRIPTION
This should follow the documented behaviour of the delta image generator, but avoids both the build complexity of including it and instead relies on the external packages and removes the need to go through another tool to end up with a (mender-)artifact.