### PR TITLE
feat(artifact): honor SOURCE_DATE_EPOCH for reproducible artifacts

### DIFF
--- a/artifact/tar_writer_file.go
+++ b/artifact/tar_writer_file.go
@@ -18,9 +18,33 @@ import (
 	"archive/tar"
 	"io"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
+
+// sourceDateEpochVar is the reproducible-builds convention for pinning
+// timestamps embedded in build output.
+// See https://reproducible-builds.org/docs/source-date-epoch/.
+const sourceDateEpochVar = "SOURCE_DATE_EPOCH"
+
+// sourceDateEpoch reports the timestamp requested by SOURCE_DATE_EPOCH, and
+// whether the variable was set at all. A malformed value is an error rather
+// than a silent fallback: a build that believes it is reproducible and is not
+// is worse than one that stops.
+func sourceDateEpoch() (time.Time, bool, error) {
+	v, ok := os.LookupEnv(sourceDateEpochVar)
+	if !ok {
+		return time.Time{}, false, nil
+	}
+	secs, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	if err != nil {
+		return time.Time{}, false, errors.Wrapf(err, "arch: invalid %s value %q", sourceDateEpochVar, v)
+	}
+	return time.Unix(secs, 0).UTC(), true, nil
+}
 
 type FileArchiver struct {
 	*tar.Writer
@@ -43,6 +67,25 @@ func (fa *FileArchiver) Write(f *os.File, archivePath string) error {
 		return errors.Wrapf(err, "arch: invalid file info header")
 	}
 	hdr.Name = archivePath
+
+	// The files reaching this writer are temporaries created during the
+	// current run, so tar.FileInfoHeader copies in an mtime that changes on
+	// every invocation and, on Linux, the building user's uid/gid. Both make
+	// otherwise identical artifacts differ byte for byte. When
+	// SOURCE_DATE_EPOCH is set, pin them -- the zero ownership this writes
+	// matches what StreamArchiver and the manifest signer already produce.
+	epoch, ok, err := sourceDateEpoch()
+	if err != nil {
+		return err
+	}
+	if ok {
+		hdr.ModTime = epoch
+		hdr.AccessTime = time.Time{}
+		hdr.ChangeTime = time.Time{}
+		hdr.Uid, hdr.Gid = 0, 0
+		hdr.Uname, hdr.Gname = "", ""
+	}
+
 	if err = fa.Writer.WriteHeader(hdr); err != nil {
 		return errors.Wrapf(err, "arch: error writing header")
 	}

--- a/artifact/tar_writer_file_test.go
+++ b/artifact/tar_writer_file_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -63,4 +64,91 @@ func TestTarFile(t *testing.T) {
 		assert.Len(t, "some data", int(n))
 		assert.Equal(t, "some data", data.String())
 	}
+}
+
+// tarFileWithMtime archives a temporary file stamped with mtime and returns
+// the resulting tar stream.
+func tarFileWithMtime(t *testing.T, mtime time.Time) []byte {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "test")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	_, err = f.WriteString("some data")
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+	assert.NoError(t, os.Chtimes(f.Name(), mtime, mtime))
+
+	f, err = os.Open(f.Name())
+	assert.NoError(t, err)
+	defer f.Close()
+
+	buf := bytes.NewBuffer(nil)
+	tw := tar.NewWriter(buf)
+	assert.NoError(t, NewTarWriterFile(tw).Write(f, "my_file"))
+	assert.NoError(t, tw.Close())
+
+	return buf.Bytes()
+}
+
+func firstHeader(t *testing.T, archive []byte) *tar.Header {
+	t.Helper()
+
+	hdr, err := tar.NewReader(bytes.NewReader(archive)).Next()
+	assert.NoError(t, err)
+	return hdr
+}
+
+// unsetSourceDateEpoch clears the variable for the duration of the test,
+// restoring whatever the ambient environment had.
+func unsetSourceDateEpoch(t *testing.T) {
+	t.Helper()
+
+	if v, ok := os.LookupEnv(sourceDateEpochVar); ok {
+		t.Setenv(sourceDateEpochVar, v)
+		assert.NoError(t, os.Unsetenv(sourceDateEpochVar))
+	}
+}
+
+func TestTarFileSourceDateEpoch(t *testing.T) {
+	t.Setenv(sourceDateEpochVar, "1000000000")
+
+	// Same content, different mtimes: the archives must still match byte for
+	// byte, which is the property the whole change exists to provide.
+	first := tarFileWithMtime(t, time.Unix(1500000000, 0))
+	second := tarFileWithMtime(t, time.Unix(1600000000, 0))
+	assert.Equal(t, first, second)
+
+	hdr := firstHeader(t, first)
+	assert.Equal(t, time.Unix(1000000000, 0).UTC(), hdr.ModTime.UTC())
+	assert.Zero(t, hdr.Uid)
+	assert.Zero(t, hdr.Gid)
+	assert.Empty(t, hdr.Uname)
+	assert.Empty(t, hdr.Gname)
+}
+
+func TestTarFileWithoutSourceDateEpoch(t *testing.T) {
+	unsetSourceDateEpoch(t)
+
+	mtime := time.Unix(1500000000, 0)
+	hdr := firstHeader(t, tarFileWithMtime(t, mtime))
+
+	// Unset means unchanged: the file's own mtime is still what lands in the
+	// header.
+	assert.Equal(t, mtime.UTC(), hdr.ModTime.UTC())
+}
+
+func TestTarFileInvalidSourceDateEpoch(t *testing.T) {
+	t.Setenv(sourceDateEpochVar, "not-a-timestamp")
+
+	f, err := os.CreateTemp("", "test")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	tw := tar.NewWriter(bytes.NewBuffer(nil))
+	err = NewTarWriterFile(tw).Write(f, "my_file")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), sourceDateEpochVar)
 }


### PR DESCRIPTION
## Problem

`mender-artifact write` is not byte-reproducible. Two runs over identical inputs, seconds apart, produce artifacts differing in exactly 7 bytes.

`FileArchiver.Write` stats the file it is archiving and builds the tar header with `tar.FileInfoHeader`. The files reaching this path are temporaries created during the run, so the header inherits an mtime that changes on every invocation and, on Linux, the uid/gid of whoever ran the build. The differing bytes land on the mtime (136–147) and header checksum (148–155) fields of the `header.tar.gz` and `data/0000.tar.gz` entries.

This appears to be the only source of non-determinism. `version` and `manifest` are already byte-identical between runs, because `StreamArchiver.Write` and the manifest signer in `awriter/signer.go` construct their headers manually with only `Name`, `Mode` and `Size` — leaving ModTime and ownership zero. The contrast is visible within a single artifact:

```
-rw------- 0/0           31  1970-01-01 00:00  version
-rw------- 0/0          242  1970-01-01 00:00  manifest
-rw------- user/group   350  2026-08-14 20:49  header.tar.gz
-rw------- user/group   129  2026-08-14 20:49  data/0000.tar.gz
```

## Change

Honor [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/). When it is set, pin the header mtime to it and zero the ownership fields. When it is unset, output is unchanged.

The zero ownership is not a new policy — it is what `StreamArchiver` and the signer already emit, so this brings the third header-writing path in line with the other two.

This is deliberately opt-in. `FileArchiver` is also used to archive the payload files themselves, whose mtimes come from the user's real input files and are surfaced by `mender-artifact read` as the `modified` field. Zeroing unconditionally would discard that, so the variable is what distinguishes "I want a reproducible build" from normal use.

## On failing loudly for a malformed value

A malformed `SOURCE_DATE_EPOCH` returns an error rather than being silently ignored. This is intentional, and I would argue it is the safer default.

The variable exists so that a caller can assert reproducibility. If the value is junk and the build quietly falls back to wall-clock mtimes, it still succeeds and still appears reproducible while silently not being — and that stays invisible until someone diffs two artifacts and has to work out why they differ. A loud failure at the point of the mistake is much cheaper than a silent one discovered later, possibly by someone else. The SOURCE_DATE_EPOCH specification also recommends exiting non-zero on a malformed value.

That said, it does introduce a failure mode that did not exist before, so if you would rather this warn or silently ignore, I am happy to change it.

## Verification

Same inputs, two builds two seconds apart:

```
with SOURCE_DATE_EPOCH set:  b9551caa…   b9551caa…    identical
without:                     0086b520…   259cea6d…    7 bytes differ
```

## Tests

Three added to `artifact/tar_writer_file_test.go`:

- identical output across differing source mtimes when the variable is set
- default behaviour preserving the file mtime when it is unset
- an error on a malformed value

The full suite passes, with the exception of `cli.TestCopyRootfsImage` and `cli.TestCopyFromStdin`, which fail identically on unmodified `master` in my environment (they need rootfs image tooling I do not have available) and are unrelated to this change.

## Possible follow-up

If you would prefer artifacts to be reproducible by default rather than opt-in, the narrower fix would be to zero mtime and ownership only where `FileArchiver` wraps the internally-created temporaries, leaving payload archiving untouched. That requires distinguishing the two roles inside `awriter/writer.go`, so I have not assumed it here — happy to follow up if that is the direction you would rather take.
