### PR TITLE
fix: Handle artifacts with empty type-info in headers gracefully

### DIFF
--- a/areader/reader.go
+++ b/areader/reader.go
@@ -48,6 +48,7 @@ type Reader struct {
 	ForbidUnknownHandlers     bool
 
 	warnOnValidationErrors bool
+	warnOnEmptyTypeInfo    bool
 	logger                 utils.Logger
 
 	shouldBeSigned  bool
@@ -85,8 +86,26 @@ func NewReaderSigned(r io.Reader) *Reader {
 	}
 }
 
+// WarnOnValidationErrors makes the reader tolerate and merely warn about
+// otherwise-fatal header-info validation errors (missing Artifact name, no
+// Payloads, etc), in addition to the empty type-info bug handled by
+// WarnOnEmptyTypeInfo. Intended for informational/best-effort reads, like
+// `read` and `dump`, not for anything that is supposed to assert that an
+// Artifact is well-formed.
 func (r *Reader) WarnOnValidationErrors(logger utils.Logger) *Reader {
 	r.warnOnValidationErrors = true
+	r.logger = logger
+	return r
+}
+
+// WarnOnEmptyTypeInfo makes the reader tolerate and merely warn about
+// Payloads with an empty type-info "type" field, a known bug in versions of
+// mender-artifact prior to 4.3.1 that does not otherwise indicate a corrupt
+// Artifact. Unlike WarnOnValidationErrors, this does not relax any other
+// validation, so it is safe to use in commands, like `validate`, that are
+// supposed to reject genuinely broken Artifacts.
+func (r *Reader) WarnOnEmptyTypeInfo(logger utils.Logger) *Reader {
+	r.warnOnEmptyTypeInfo = true
 	r.logger = logger
 	return r
 }
@@ -917,7 +936,12 @@ func (ar *Reader) readHeaderUpdate(tr *tar.Reader, hdr *tar.Header, augmented bo
 				return errors.Errorf("reader: can not find parser for Payload: %v", hdr.Name)
 			}
 			if hErr := inst.ReadHeader(tr, hdr.Name, ar.info.Version, augmented); hErr != nil {
-				return errors.Wrap(hErr, "reader: can not read header")
+				if errors.Cause(hErr) == handlers.ErrTypeInfoEmpty &&
+					(ar.warnOnValidationErrors || ar.warnOnEmptyTypeInfo) {
+					ar.logger.Warn(fmt.Sprintf("reader: %s", hErr.Error()))
+				} else {
+					return errors.Wrap(hErr, "reader: can not read header")
+				}
 			}
 		}
 

--- a/areader/reader.go
+++ b/areader/reader.go
@@ -100,7 +100,7 @@ func (r *Reader) WarnOnValidationErrors(logger utils.Logger) *Reader {
 
 // WarnOnEmptyTypeInfo makes the reader tolerate and merely warn about
 // Payloads with an empty type-info "type" field, a known bug in versions of
-// mender-artifact prior to 4.3.1 that does not otherwise indicate a corrupt
+// mender-artifact prior to 4.4.0 that does not otherwise indicate a corrupt
 // Artifact. Unlike WarnOnValidationErrors, this does not relax any other
 // validation, so it is safe to use in commands, like `validate`, that are
 // supposed to reject genuinely broken Artifacts.

--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -1348,7 +1348,7 @@ func TestReadBrokenArtifact(t *testing.T) {
 			successful: false,
 			errorStr:   "Top level object in meta-data must be a JSON object",
 		},
-		"Non-matching type in type-info, module-image": {
+		"Empty type in type-info, module-image": {
 			manipulateArtifact: func(tmpdir string) {
 				headertmp := filepath.Join(tmpdir, "headertmp")
 				require.NoError(t, os.Mkdir(headertmp, 0755))
@@ -1391,9 +1391,9 @@ func TestReadBrokenArtifact(t *testing.T) {
 				fd.Close()
 			},
 			successful: false,
-			errorStr:   "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header does not match header-info: Corrupt Artifact. This is a known bug in some versions of mender-artifact prior to 4.3.1. Please recreate the artifact with version 4.3.1 or newer.",
+			errorStr:   "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header is empty: This is a known bug in some versions of mender-artifact prior to 4.3.1. Please recreate the artifact with version 4.3.1 or newer.",
 		},
-		"Non-matching type in type-info, rootfs-image": {
+		"Empty type in type-info, rootfs-image": {
 			manipulateArtifact: func(tmpdir string) {
 				headertmp := filepath.Join(tmpdir, "headertmp")
 				require.NoError(t, os.Mkdir(headertmp, 0755))
@@ -1437,7 +1437,98 @@ func TestReadBrokenArtifact(t *testing.T) {
 			},
 			rootfsImage: true,
 			successful:  false,
-			errorStr:    "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header does not match header-info: Corrupt Artifact. This is a known bug in some versions of mender-artifact prior to 4.3.1. Please recreate the artifact with version 4.3.1 or newer.",
+			errorStr:    "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header is empty: This is a known bug in some versions of mender-artifact prior to 4.3.1. Please recreate the artifact with version 4.3.1 or newer.",
+		},
+		"Non-matching type in type-info, module-image": {
+			manipulateArtifact: func(tmpdir string) {
+				headertmp := filepath.Join(tmpdir, "headertmp")
+				require.NoError(t, os.Mkdir(headertmp, 0755))
+				cmd := exec.Command("tar", "xzf", "../header.tar.gz")
+				cmd.Dir = headertmp
+				require.NoError(t, cmd.Run())
+
+				fd, err := os.OpenFile(filepath.Join(headertmp, "headers/0000/type-info"),
+					os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+				require.NoError(t, err)
+				fd.Write([]byte(`{"type":"other-type"}`))
+				fd.Close()
+
+				cmd = exec.Command("tar", "czf", "../header.tar.gz", "header-info", "headers")
+				cmd.Dir = headertmp
+				require.NoError(t, cmd.Run())
+
+				fd, err = os.Open(filepath.Join(tmpdir, "header.tar.gz"))
+				require.NoError(t, err)
+				content, err := io.ReadAll(fd)
+				require.NoError(t, err)
+				fd.Close()
+				checksumBytes := sha256.Sum256(content)
+				checksum := hex.EncodeToString(checksumBytes[:])
+
+				fd, err = os.OpenFile(filepath.Join(tmpdir, "manifest"),
+					os.O_RDWR, 0)
+				require.NoError(t, err)
+				manifestLines, err := io.ReadAll(fd)
+				require.NoError(t, err)
+				fd.Seek(0, 0)
+				fd.Truncate(0)
+				for _, line := range bytes.Split(manifestLines, []byte("\n")) {
+					if strings.Contains(string(line), "header.tar.gz") {
+						copy(line[0:len(checksum)], checksum)
+					}
+					fd.Write(line)
+					fd.Write([]byte("\n"))
+				}
+				fd.Close()
+			},
+			successful: false,
+			errorStr:   "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header does not match header-info: Corrupt Artifact.",
+		},
+		"Non-matching type in type-info, rootfs-image": {
+			manipulateArtifact: func(tmpdir string) {
+				headertmp := filepath.Join(tmpdir, "headertmp")
+				require.NoError(t, os.Mkdir(headertmp, 0755))
+				cmd := exec.Command("tar", "xzf", "../header.tar.gz")
+				cmd.Dir = headertmp
+				require.NoError(t, cmd.Run())
+
+				fd, err := os.OpenFile(filepath.Join(headertmp, "headers/0000/type-info"),
+					os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+				require.NoError(t, err)
+				fd.Write([]byte(`{"type":"other-type"}`))
+				fd.Close()
+
+				cmd = exec.Command("tar", "czf", "../header.tar.gz", "header-info", "headers")
+				cmd.Dir = headertmp
+				require.NoError(t, cmd.Run())
+
+				fd, err = os.Open(filepath.Join(tmpdir, "header.tar.gz"))
+				require.NoError(t, err)
+				content, err := io.ReadAll(fd)
+				require.NoError(t, err)
+				fd.Close()
+				checksumBytes := sha256.Sum256(content)
+				checksum := hex.EncodeToString(checksumBytes[:])
+
+				fd, err = os.OpenFile(filepath.Join(tmpdir, "manifest"),
+					os.O_RDWR, 0)
+				require.NoError(t, err)
+				manifestLines, err := io.ReadAll(fd)
+				require.NoError(t, err)
+				fd.Seek(0, 0)
+				fd.Truncate(0)
+				for _, line := range bytes.Split(manifestLines, []byte("\n")) {
+					if strings.Contains(string(line), "header.tar.gz") {
+						copy(line[0:len(checksum)], checksum)
+					}
+					fd.Write(line)
+					fd.Write([]byte("\n"))
+				}
+				fd.Close()
+			},
+			rootfsImage: true,
+			successful:  false,
+			errorStr:    "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header does not match header-info: Corrupt Artifact.",
 		},
 	}
 
@@ -1492,6 +1583,106 @@ func TestReadBrokenArtifact(t *testing.T) {
 			assert.Equal(t, c.numAugmentFiles, len(handler.GetUpdateAugmentFiles()))
 		})
 	}
+}
+
+type spyLogger struct {
+	warnings []string
+}
+
+func (l *spyLogger) Error(args ...any) {}
+func (l *spyLogger) Warn(args ...any) {
+	l.warnings = append(l.warnings, fmt.Sprint(args...))
+}
+func (l *spyLogger) Info(args ...any)  {}
+func (l *spyLogger) Debug(args ...any) {}
+
+func setTypeInfoAndFixManifest(t *testing.T, tmpdir string, typeInfo string) {
+	headertmp := filepath.Join(tmpdir, "headertmp")
+	require.NoError(t, os.Mkdir(headertmp, 0755))
+	cmd := exec.Command("tar", "xzf", "../header.tar.gz")
+	cmd.Dir = headertmp
+	require.NoError(t, cmd.Run())
+
+	fd, err := os.OpenFile(filepath.Join(headertmp, "headers/0000/type-info"),
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	fd.Write([]byte(typeInfo))
+	fd.Close()
+
+	cmd = exec.Command("tar", "czf", "../header.tar.gz", "header-info", "headers")
+	cmd.Dir = headertmp
+	require.NoError(t, cmd.Run())
+
+	fd, err = os.Open(filepath.Join(tmpdir, "header.tar.gz"))
+	require.NoError(t, err)
+	content, err := io.ReadAll(fd)
+	require.NoError(t, err)
+	fd.Close()
+	checksumBytes := sha256.Sum256(content)
+	checksum := hex.EncodeToString(checksumBytes[:])
+
+	fd, err = os.OpenFile(filepath.Join(tmpdir, "manifest"), os.O_RDWR, 0)
+	require.NoError(t, err)
+	manifestLines, err := io.ReadAll(fd)
+	require.NoError(t, err)
+	fd.Seek(0, 0)
+	fd.Truncate(0)
+	for _, line := range bytes.Split(manifestLines, []byte("\n")) {
+		if strings.Contains(string(line), "header.tar.gz") {
+			copy(line[0:len(checksum)], checksum)
+		}
+		fd.Write(line)
+		fd.Write([]byte("\n"))
+	}
+	fd.Close()
+}
+
+func makeArtifactWithTypeInfo(t *testing.T, typeInfo string) io.Reader {
+	art, err := MakeModuleImageArtifact(false, false, "test-type", 1, 0)
+	require.NoError(t, err)
+
+	tmpdir, err := os.MkdirTemp("", "mender-TestReadArtifactTypeInfoWarning")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpdir) })
+
+	cmd := exec.Command("tar", "x")
+	cmd.Stdin = art
+	cmd.Dir = tmpdir
+	require.NoError(t, cmd.Run())
+
+	setTypeInfoAndFixManifest(t, tmpdir, typeInfo)
+
+	pipeR, pipeW := io.Pipe()
+	cmd = exec.Command("tar", assembleSubset([]string{"c"}, tmpdir)...)
+	cmd.Stdout = pipeW
+	cmd.Dir = tmpdir
+	require.NoError(t, cmd.Start())
+	return pipeR
+}
+
+func TestReadArtifactEmptyTypeInfoIsOnlyAWarning(t *testing.T) {
+	art := makeArtifactWithTypeInfo(t, `{"type":""}`)
+
+	logger := &spyLogger{}
+	r := NewReader(art)
+	r.WarnOnValidationErrors(logger)
+	err := r.ReadArtifact()
+	require.NoError(t, err)
+	require.Len(t, logger.warnings, 1)
+	assert.Contains(t, logger.warnings[0], "Type in type-info header is empty")
+}
+
+func TestReadArtifactMismatchingTypeInfoIsAlwaysAnError(t *testing.T) {
+	art := makeArtifactWithTypeInfo(t, `{"type":"other-type"}`)
+
+	logger := &spyLogger{}
+	r := NewReader(art)
+	r.WarnOnValidationErrors(logger)
+	err := r.ReadArtifact()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"Type in type-info header does not match header-info: Corrupt Artifact.")
+	assert.Empty(t, logger.warnings)
 }
 
 func TestMergeDependsSuccess(t *testing.T) {

--- a/areader/reader_test.go
+++ b/areader/reader_test.go
@@ -1391,7 +1391,7 @@ func TestReadBrokenArtifact(t *testing.T) {
 				fd.Close()
 			},
 			successful: false,
-			errorStr:   "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header is empty: This is a known bug in some versions of mender-artifact prior to 4.3.1. Please recreate the artifact with version 4.3.1 or newer.",
+			errorStr:   "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header is empty: This is a known bug in some versions of mender-artifact prior to 4.4.0. Please recreate the artifact with version 4.4.0 or newer.",
 		},
 		"Empty type in type-info, rootfs-image": {
 			manipulateArtifact: func(tmpdir string) {
@@ -1437,7 +1437,7 @@ func TestReadBrokenArtifact(t *testing.T) {
 			},
 			rootfsImage: true,
 			successful:  false,
-			errorStr:    "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header is empty: This is a known bug in some versions of mender-artifact prior to 4.3.1. Please recreate the artifact with version 4.3.1 or newer.",
+			errorStr:    "readHeaderV3: handleHeaderReads: reader: can not read header: Type in type-info header is empty: This is a known bug in some versions of mender-artifact prior to 4.4.0. Please recreate the artifact with version 4.4.0 or newer.",
 		},
 		"Non-matching type in type-info, module-image": {
 			manipulateArtifact: func(tmpdir string) {

--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -203,6 +203,7 @@ func unpackArtifact(name string) (ua *unpackedArtifact, err error) {
 	defer f.Close()
 
 	aReader := areader.NewReader(f)
+	aReader.WarnOnEmptyTypeInfo(Log)
 	ua.ar = aReader
 
 	tmpdir, err := os.MkdirTemp("", "mender-artifact")

--- a/cli/dump.go
+++ b/cli/dump.go
@@ -52,6 +52,7 @@ func DumpCommand(c *cli.Context) error {
 	defer art.Close()
 
 	ar := areader.NewReader(art)
+	ar.WarnOnValidationErrors(Log)
 
 	scriptsReadCallback := func(r io.Reader, i os.FileInfo) error {
 		fullPath := path.Join(c.String("scripts"), i.Name())

--- a/cli/partition.go
+++ b/cli/partition.go
@@ -121,6 +121,7 @@ func (v vImage) Open(
 	defer art.Close()
 
 	aReader := areader.NewReader(art)
+	aReader.WarnOnEmptyTypeInfo(Log)
 	err = aReader.ReadArtifact()
 	if err == nil {
 		// we have VALID artifact,

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -33,6 +33,7 @@ func validate(art io.Reader, key artifact.Verifier) error {
 	var validationError error
 
 	ar := areader.NewReader(art)
+	ar.WarnOnEmptyTypeInfo(Log)
 	ar.VerifySignatureCallback = func(message, sig []byte) error {
 		if key != nil {
 			if err := key.Verify(message, sig); err != nil {

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -40,6 +40,22 @@ type DataFile struct {
 	Checksum []byte
 }
 
+// ErrTypeInfoEmpty is returned (and, depending on the reader configuration,
+// only warned about) when the "type" field in a Payload's type-info header
+// is empty. This is known to be produced by versions of mender-artifact
+// prior to 4.3.1, and is not by itself indicative of a corrupt Artifact.
+var ErrTypeInfoEmpty = errors.New("Type in type-info header is empty: " +
+	"This is a known bug in some versions of mender-artifact prior to 4.3.1. " +
+	"Please recreate the artifact with version 4.3.1 or newer.")
+
+// ErrTypeInfoMismatch is returned when the "type" field in a Payload's
+// type-info header is set, but does not match the type declared in
+// header-info. Unlike ErrTypeInfoEmpty, this is always treated as an error,
+// since no released version of mender-artifact is known to produce such an
+// Artifact.
+var ErrTypeInfoMismatch = errors.New("Type in type-info header does not match header-info: " +
+	"Corrupt Artifact.")
+
 type ComposeHeaderArgs struct {
 	TarWriter  *tar.Writer
 	No         int

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -43,10 +43,10 @@ type DataFile struct {
 // ErrTypeInfoEmpty is returned (and, depending on the reader configuration,
 // only warned about) when the "type" field in a Payload's type-info header
 // is empty. This is known to be produced by versions of mender-artifact
-// prior to 4.3.1, and is not by itself indicative of a corrupt Artifact.
+// prior to 4.4.0, and is not by itself indicative of a corrupt Artifact.
 var ErrTypeInfoEmpty = errors.New("Type in type-info header is empty: " +
-	"This is a known bug in some versions of mender-artifact prior to 4.3.1. " +
-	"Please recreate the artifact with version 4.3.1 or newer.")
+	"This is a known bug in some versions of mender-artifact prior to 4.4.0. " +
+	"Please recreate the artifact with version 4.4.0 or newer.")
 
 // ErrTypeInfoMismatch is returned when the "type" field in a Payload's
 // type-info header is set, but does not match the type declared in

--- a/handlers/module_image.go
+++ b/handlers/module_image.go
@@ -469,11 +469,10 @@ func (img *ModuleImage) ReadHeader(r io.Reader, path string, version int, augmen
 		if err != nil {
 			return errors.Wrap(err, "error reading type-info")
 		}
-		if img.typeInfoV3 == nil || *img.typeInfoV3.Type != img.updateType {
-			return errors.New("Type in type-info header does not match header-info: " +
-				"Corrupt Artifact. " +
-				"This is a known bug in some versions of mender-artifact prior to 4.3.1. " +
-				"Please recreate the artifact with version 4.3.1 or newer.")
+		if img.typeInfoV3 == nil || img.typeInfoV3.Type == nil || *img.typeInfoV3.Type == "" {
+			return ErrTypeInfoEmpty
+		} else if *img.typeInfoV3.Type != img.updateType {
+			return ErrTypeInfoMismatch
 		}
 	case match("headers/*/meta-data", path):
 		dec := json.NewDecoder(r)

--- a/handlers/rootfs_image.go
+++ b/handlers/rootfs_image.go
@@ -135,11 +135,10 @@ func (rp *Rootfs) ReadHeader(r io.Reader, path string, version int, augmented bo
 		if err != nil {
 			return errors.Wrap(err, "error reading type-info")
 		}
-		if rp.typeInfoV3.Type == nil || *rp.typeInfoV3.Type != "rootfs-image" {
-			return errors.New("Type in type-info header does not match header-info: " +
-				"Corrupt Artifact. " +
-				"This is a known bug in some versions of mender-artifact prior to 4.3.1. " +
-				"Please recreate the artifact with version 4.3.1 or newer.")
+		if rp.typeInfoV3 == nil || rp.typeInfoV3.Type == nil || *rp.typeInfoV3.Type == "" {
+			return ErrTypeInfoEmpty
+		} else if *rp.typeInfoV3.Type != "rootfs-image" {
+			return ErrTypeInfoMismatch
 		}
 
 	case match("headers/*/meta-data", path):


### PR DESCRIPTION
Although such artifacts don't strictly adhere to the format
specification, past versions of mender-artifact itself produced
such artifacts. Rejecting them as invalid/corrupt causes issues
in many places because it's very hard to recreate all past
artifacts with the latest version of mender-artifact.

Artifacts with an actual mismatch between the two type-info
fields are still rejected because that's an indication of a real
issue with Artifact creation as no past versions of
mender-artifact have done that.

Ticket: MEN-9561
Changelog: Artifacts produced by past versions of mender-artifact
missing type-info in headers are no longer rejected as
invalid/corrupt
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Vratislav Podzimek <vratislav.podzimek+auto-signed@northern.tech>