### PR TITLE
ci: update remote license file path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ include:
       compass_component_id: "3a6f19a5-306f-4900-93f6-c2e953eac6e8"
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-oslicenses-golang@master
     inputs:
-      remote_license_file: "302.Release-information/03.Open-source-licenses/30.mender-artifact/docs.md"
+      remote_license_file: "302.Release-information/04.Open-source-licenses/30.mender-artifact/docs.md"
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-docs-changelog@master
     inputs:
       remote_changelog_file: "30.mender-artifact/docs.md"


### PR DESCRIPTION
The path has been changed from `302.Release-information/03.Open-source-licenses` to `302.Release-information/04.Open-source-licenses`

Ticket: QA-1744